### PR TITLE
Vector Field Opacity

### DIFF
--- a/src/display/VectorField.tsx
+++ b/src/display/VectorField.tsx
@@ -8,6 +8,7 @@ export interface VectorFieldProps {
   xy: (x: number, y: number) => [number, number]
   opacity: (x: number, y: number) => number
   step: number
+  opacityStep: number
   color?: string
 }
 
@@ -28,7 +29,7 @@ interface Layer {
  * @param opacityGrainularity the granulity of the opacity layers
  * @returns a list of layers
  */
-function generateOpacityLayers (opacityGrainularity: number = 5): Layer[] {
+function generateOpacityLayers (opacityGrainularity: number): Layer[] {
   var layers: Layer[] = []
   const step = 1/opacityGrainularity;
   for (var i = 1; i > 0; i-=step) {
@@ -60,11 +61,16 @@ function findClosetLayer (layers: Layer[], pointOpacity: number): Layer {
   return bestLayer
 }
 
-const VectorField: React.VFC<VectorFieldProps> = ({ xy, opacity = (x,y)=>1, step = 1, color = "var(--mafs-fg)" }) => {
+const VectorField: React.VFC<VectorFieldProps> = ({ xy, opacity = (x,y)=>1, step = 1, opacityStep = 0.2, color = "var(--mafs-fg)" }) => {
   const { pixelMatrix } = useScaleContext()
   const { xPanes, yPanes } = usePaneContext()
 
-  const layers = generateOpacityLayers();
+  //Impose restrictions on opacityStep
+  opacityStep = Math.min(1,Math.max(0.01,opacityStep))
+  //Calculate grainularity from step
+  var opacityGrainularity = Math.ceil(1/opacityStep)
+  //Create layers
+  const layers = generateOpacityLayers(opacityGrainularity);
 
   function fieldForRegion(xMin: number, xMax: number, yMin: number, yMax: number) {
     for (let x = Math.floor(xMin); x <= Math.ceil(xMax); x += step) {

--- a/src/display/VectorField.tsx
+++ b/src/display/VectorField.tsx
@@ -6,7 +6,7 @@ import { useScaleContext } from "view/ScaleContext"
 
 export interface VectorFieldProps {
   xy: (x: number, y: number) => [number, number]
-  opacity: (x: number, y: number) => number
+  xyOpacity: (x: number, y: number) => number
   step: number
   opacityStep: number
   color?: string
@@ -61,7 +61,7 @@ function findClosetLayer (layers: Layer[], pointOpacity: number): Layer {
   return bestLayer
 }
 
-const VectorField: React.VFC<VectorFieldProps> = ({ xy, opacity = (x,y)=>1, step = 1, opacityStep = 0.2, color = "var(--mafs-fg)" }) => {
+const VectorField: React.VFC<VectorFieldProps> = ({ xy, xyOpacity = (x,y)=>1, step = 1, opacityStep = 0.2, color = "var(--mafs-fg)" }) => {
   const { pixelMatrix } = useScaleContext()
   const { xPanes, yPanes } = usePaneContext()
 
@@ -90,7 +90,7 @@ const VectorField: React.VFC<VectorFieldProps> = ({ xy, opacity = (x,y)=>1, step
         const left = vec.add(pixelTip, vec.rotate(arrowVector, (5 / 6) * Math.PI))
         const right = vec.add(pixelTip, vec.rotate(arrowVector, -(5 / 6) * Math.PI))
 
-        const trueOpacity = opacity(x,y)
+        const trueOpacity = xyOpacity(x,y)
         var layer = findClosetLayer(layers,trueOpacity)
         layer.d +=
           ` M ${pixelTail[0]} ${pixelTail[1]}` +

--- a/src/display/VectorField.tsx
+++ b/src/display/VectorField.tsx
@@ -15,27 +15,27 @@ export interface VectorFieldProps {
 export type Vector = [number, number]
 
 interface Layer {
-  d:string,
-  opacity:number
+  d: string
+  opacity: number
 }
 
 /**
- * Generates a list of layers. Each layer will eventually be convereted to a <path> 
+ * Generates a list of layers. Each layer will eventually be convereted to a <path>
  * with a certain opacity.
- * 
- * The higher the opacityGrainularity, the more fidelity you get accross opacities, 
+ *
+ * The higher the opacityGrainularity, the more fidelity you get accross opacities,
  * however the more layers you have, the more lag you get.
- * 
+ *
  * @param opacityGrainularity the granulity of the opacity layers
  * @returns a list of layers
  */
-function generateOpacityLayers (opacityGrainularity: number): Layer[] {
+function generateOpacityLayers(opacityGrainularity: number): Layer[] {
   var layers: Layer[] = []
-  const step = 1/opacityGrainularity;
-  for (var i = 1; i > 0; i-=step) {
-    var layer: Layer ={
+  const step = 1 / opacityGrainularity
+  for (var i = 1; i > 0; i -= step) {
+    var layer: Layer = {
       d: "",
-      opacity: i
+      opacity: i,
     }
     layers.push(layer)
   }
@@ -44,15 +44,15 @@ function generateOpacityLayers (opacityGrainularity: number): Layer[] {
 
 /**
  * Takes in a pointOpacity (a number) and returns the layer it belongs to from layers.
- * 
+ *
  * @param layers the layers to catagorize pointOpacity to.
  * @param pointOpacity the opacity to categorize to a layer.
  * @return the layer that this opacity value belongs to.
  */
-function findClosetLayer (layers: Layer[], pointOpacity: number): Layer {
-  var bestLayer: Layer = layers[0];
-  for (let layer of layers){
-    if (layer.opacity>pointOpacity){
+function findClosetLayer(layers: Layer[], pointOpacity: number): Layer {
+  var bestLayer: Layer = layers[0]
+  for (let layer of layers) {
+    if (layer.opacity > pointOpacity) {
       bestLayer = layer
     } else {
       break
@@ -61,16 +61,22 @@ function findClosetLayer (layers: Layer[], pointOpacity: number): Layer {
   return bestLayer
 }
 
-const VectorField: React.VFC<VectorFieldProps> = ({ xy, xyOpacity = (x,y)=>1, step = 1, opacityStep = 0.2, color = "var(--mafs-fg)" }) => {
+const VectorField: React.VFC<VectorFieldProps> = ({
+  xy,
+  xyOpacity = (x, y) => 1,
+  step = 1,
+  opacityStep = 0.2,
+  color = "var(--mafs-fg)",
+}) => {
   const { pixelMatrix } = useScaleContext()
   const { xPanes, yPanes } = usePaneContext()
 
   //Impose restrictions on opacityStep
-  opacityStep = Math.min(1,Math.max(0.01,opacityStep))
+  opacityStep = Math.min(1, Math.max(0.01, opacityStep))
   //Calculate grainularity from step
-  var opacityGrainularity = Math.ceil(1/opacityStep)
+  var opacityGrainularity = Math.ceil(1 / opacityStep)
   //Create layers
-  const layers = generateOpacityLayers(opacityGrainularity);
+  const layers = generateOpacityLayers(opacityGrainularity)
 
   function fieldForRegion(xMin: number, xMax: number, yMin: number, yMax: number) {
     for (let x = Math.floor(xMin); x <= Math.ceil(xMax); x += step) {
@@ -90,8 +96,8 @@ const VectorField: React.VFC<VectorFieldProps> = ({ xy, xyOpacity = (x,y)=>1, st
         const left = vec.add(pixelTip, vec.rotate(arrowVector, (5 / 6) * Math.PI))
         const right = vec.add(pixelTip, vec.rotate(arrowVector, -(5 / 6) * Math.PI))
 
-        const trueOpacity = xyOpacity(x,y)
-        var layer = findClosetLayer(layers,trueOpacity)
+        const trueOpacity = xyOpacity(x, y)
+        var layer = findClosetLayer(layers, trueOpacity)
         layer.d +=
           ` M ${pixelTail[0]} ${pixelTail[1]}` +
           ` L ${pixelTip[0]} ${pixelTip[1]} ` +
@@ -106,7 +112,7 @@ const VectorField: React.VFC<VectorFieldProps> = ({ xy, xyOpacity = (x,y)=>1, st
     for (const [yMin, yMax] of yPanes) {
       fieldForRegion(xMin, xMax, yMin, yMax)
     }
-  } 
+  }
 
   return (
     <>
@@ -114,13 +120,13 @@ const VectorField: React.VFC<VectorFieldProps> = ({ xy, xyOpacity = (x,y)=>1, st
         <path
           d={layer.d}
           key={index}
-          style={{ 
-            stroke: color || "var(--mafs-fg)", 
+          style={{
+            stroke: color || "var(--mafs-fg)",
             fill: color || "var(--mafs-fg)",
             opacity: layer.opacity,
             fillOpacity: layer.opacity,
-            strokeOpacity: layer.opacity
-            }}
+            strokeOpacity: layer.opacity,
+          }}
           strokeLinecap="round"
           strokeLinejoin="round"
         />

--- a/src/display/VectorField.tsx
+++ b/src/display/VectorField.tsx
@@ -26,8 +26,8 @@ const VectorField: React.VFC<VectorFieldProps> = ({
 
   //Impose restrictions on opacityStep
   opacityStep = Math.min(1, Math.max(0.01, opacityStep))
-  //Calculate grainularity from step
-  var opacityGrainularity = Math.ceil(1 / opacityStep)
+  //Calculate granularity from step
+  const opacityGrainularity = Math.ceil(1 / opacityStep)
   //Create layers
   const layers = generateOpacityLayers(opacityGrainularity)
 
@@ -50,7 +50,7 @@ const VectorField: React.VFC<VectorFieldProps> = ({
         const right = vec.add(pixelTip, vec.rotate(arrowVector, -(5 / 6) * Math.PI))
 
         const trueOpacity = xyOpacity(x, y)
-        var layer = findClosetLayer(layers, trueOpacity)
+        const layer = findClosetLayer(layers, trueOpacity)
         layer.d +=
           ` M ${pixelTail[0]} ${pixelTail[1]}` +
           ` L ${pixelTip[0]} ${pixelTip[1]} ` +
@@ -106,10 +106,10 @@ interface Layer {
  * @returns a list of layers
  */
 function generateOpacityLayers(opacityGrainularity: number): Layer[] {
-  var layers: Layer[] = []
+  const layers: Layer[] = []
   const step = 1 / opacityGrainularity
-  for (var i = 1; i > 0; i -= step) {
-    var layer: Layer = {
+  for (let i = 1; i > 0; i -= step) {
+    const layer: Layer = {
       d: "",
       opacity: i,
     }
@@ -126,13 +126,15 @@ function generateOpacityLayers(opacityGrainularity: number): Layer[] {
  * @return the layer that this opacity value belongs to.
  */
 function findClosetLayer(layers: Layer[], pointOpacity: number): Layer {
-  var bestLayer: Layer = layers[0]
-  for (let layer of layers) {
+  let bestLayer: Layer = layers[0]
+
+  for (const layer of layers) {
     if (layer.opacity > pointOpacity) {
       bestLayer = layer
     } else {
       break
     }
   }
+
   return bestLayer
 }

--- a/src/display/VectorField.tsx
+++ b/src/display/VectorField.tsx
@@ -6,19 +6,67 @@ import { useScaleContext } from "view/ScaleContext"
 
 export interface VectorFieldProps {
   xy: (x: number, y: number) => [number, number]
+  opacity: (x: number, y: number) => number
   step: number
   color?: string
 }
 
 export type Vector = [number, number]
 
-const VectorField: React.VFC<VectorFieldProps> = ({ xy, step = 1, color = "var(--mafs-fg)" }) => {
+interface Layer {
+  d:string,
+  opacity:number
+}
+
+/**
+ * Generates a list of layers. Each layer will eventually be convereted to a <path> 
+ * with a certain opacity.
+ * 
+ * The higher the opacityGrainularity, the more fidelity you get accross opacities, 
+ * however the more layers you have, the more lag you get.
+ * 
+ * @param opacityGrainularity the granulity of the opacity layers
+ * @returns a list of layers
+ */
+function generateOpacityLayers (opacityGrainularity: number = 5): Layer[] {
+  var layers: Layer[] = []
+  const step = 1/opacityGrainularity;
+  for (var i = 1; i > 0; i-=step) {
+    var layer: Layer ={
+      d: "",
+      opacity: i
+    }
+    layers.push(layer)
+  }
+  return layers
+}
+
+/**
+ * Takes in a pointOpacity (a number) and returns the layer it belongs to from layers.
+ * 
+ * @param layers the layers to catagorize pointOpacity to.
+ * @param pointOpacity the opacity to categorize to a layer.
+ * @return the layer that this opacity value belongs to.
+ */
+function findClosetLayer (layers: Layer[], pointOpacity: number): Layer {
+  var bestLayer: Layer = layers[0];
+  for (let layer of layers){
+    if (layer.opacity>pointOpacity){
+      bestLayer = layer
+    } else {
+      break
+    }
+  }
+  return bestLayer
+}
+
+const VectorField: React.VFC<VectorFieldProps> = ({ xy, opacity = (x,y)=>1, step = 1, color = "var(--mafs-fg)" }) => {
   const { pixelMatrix } = useScaleContext()
   const { xPanes, yPanes } = usePaneContext()
 
-  function fieldForRegion(xMin: number, xMax: number, yMin: number, yMax: number) {
-    let d = ""
+  const layers = generateOpacityLayers();
 
+  function fieldForRegion(xMin: number, xMax: number, yMin: number, yMax: number) {
     for (let x = Math.floor(xMin); x <= Math.ceil(xMax); x += step) {
       for (let y = Math.floor(yMin); y <= Math.ceil(yMax); y += step) {
         const tail: Vector = [x, y]
@@ -36,7 +84,9 @@ const VectorField: React.VFC<VectorFieldProps> = ({ xy, step = 1, color = "var(-
         const left = vec.add(pixelTip, vec.rotate(arrowVector, (5 / 6) * Math.PI))
         const right = vec.add(pixelTip, vec.rotate(arrowVector, -(5 / 6) * Math.PI))
 
-        d +=
+        const trueOpacity = opacity(x,y)
+        var layer = findClosetLayer(layers,trueOpacity)
+        layer.d +=
           ` M ${pixelTail[0]} ${pixelTail[1]}` +
           ` L ${pixelTip[0]} ${pixelTip[1]} ` +
           ` L ${left[0]} ${left[1]} ` +
@@ -44,25 +94,27 @@ const VectorField: React.VFC<VectorFieldProps> = ({ xy, step = 1, color = "var(-
           ` L ${pixelTip[0]} ${pixelTip[1]} `
       }
     }
-
-    return d
   }
-
-  const fields: string[] = []
 
   for (const [xMin, xMax] of xPanes) {
     for (const [yMin, yMax] of yPanes) {
-      fields.push(fieldForRegion(xMin, xMax, yMin, yMax))
+      fieldForRegion(xMin, xMax, yMin, yMax)
     }
-  }
+  } 
 
   return (
     <>
-      {fields.map((d, index) => (
+      {layers.map((layer, index) => (
         <path
-          d={d}
+          d={layer.d}
           key={index}
-          style={{ stroke: color || "var(--mafs-fg)", fill: color || "var(--mafs-fg)" }}
+          style={{ 
+            stroke: color || "var(--mafs-fg)", 
+            fill: color || "var(--mafs-fg)",
+            opacity: layer.opacity,
+            fillOpacity: layer.opacity,
+            strokeOpacity: layer.opacity
+            }}
           strokeLinecap="round"
           strokeLinejoin="round"
         />

--- a/src/display/VectorField.tsx
+++ b/src/display/VectorField.tsx
@@ -14,53 +14,6 @@ export interface VectorFieldProps {
 
 export type Vector = [number, number]
 
-interface Layer {
-  d: string
-  opacity: number
-}
-
-/**
- * Generates a list of layers. Each layer will eventually be convereted to a <path>
- * with a certain opacity.
- *
- * The higher the opacityGrainularity, the more fidelity you get accross opacities,
- * however the more layers you have, the more lag you get.
- *
- * @param opacityGrainularity the granulity of the opacity layers
- * @returns a list of layers
- */
-function generateOpacityLayers(opacityGrainularity: number): Layer[] {
-  var layers: Layer[] = []
-  const step = 1 / opacityGrainularity
-  for (var i = 1; i > 0; i -= step) {
-    var layer: Layer = {
-      d: "",
-      opacity: i,
-    }
-    layers.push(layer)
-  }
-  return layers
-}
-
-/**
- * Takes in a pointOpacity (a number) and returns the layer it belongs to from layers.
- *
- * @param layers the layers to catagorize pointOpacity to.
- * @param pointOpacity the opacity to categorize to a layer.
- * @return the layer that this opacity value belongs to.
- */
-function findClosetLayer(layers: Layer[], pointOpacity: number): Layer {
-  var bestLayer: Layer = layers[0]
-  for (let layer of layers) {
-    if (layer.opacity > pointOpacity) {
-      bestLayer = layer
-    } else {
-      break
-    }
-  }
-  return bestLayer
-}
-
 const VectorField: React.VFC<VectorFieldProps> = ({
   xy,
   xyOpacity = (x, y) => 1,
@@ -136,3 +89,50 @@ const VectorField: React.VFC<VectorFieldProps> = ({
 }
 
 export default VectorField
+
+interface Layer {
+  d: string
+  opacity: number
+}
+
+/**
+ * Generates a list of layers. Each layer will eventually be convereted to a <path>
+ * with a certain opacity.
+ *
+ * The higher the opacityGrainularity, the more fidelity you get accross opacities,
+ * however the more layers you have, the more lag you get.
+ *
+ * @param opacityGrainularity the granulity of the opacity layers
+ * @returns a list of layers
+ */
+function generateOpacityLayers(opacityGrainularity: number): Layer[] {
+  var layers: Layer[] = []
+  const step = 1 / opacityGrainularity
+  for (var i = 1; i > 0; i -= step) {
+    var layer: Layer = {
+      d: "",
+      opacity: i,
+    }
+    layers.push(layer)
+  }
+  return layers
+}
+
+/**
+ * Takes in a pointOpacity (a number) and returns the layer it belongs to from layers.
+ *
+ * @param layers the layers to catagorize pointOpacity to.
+ * @param pointOpacity the opacity to categorize to a layer.
+ * @return the layer that this opacity value belongs to.
+ */
+function findClosetLayer(layers: Layer[], pointOpacity: number): Layer {
+  var bestLayer: Layer = layers[0]
+  for (let layer of layers) {
+    if (layer.opacity > pointOpacity) {
+      bestLayer = layer
+    } else {
+      break
+    }
+  }
+  return bestLayer
+}


### PR DESCRIPTION
### The problem
Vector fields can get really messy when vectors get really long. A solution to this, without reducing amount of information conveyed, is to make vectors more or less opaque depending on how large their magnitude is. Currently, maf does not support this.

### The feature
Let VectorField take another function parameter `opacity(x:number,y:number) => number`. (This defaults to `opacity(x:number,y:number) => 1`, e.i all the vectors will be fully opaque by default.) This behaves very similarly to the `xy` parameter function, but returns a single number instead of a vector. This function maps an opacity value (a float ideally from 0 to 1) from each (x,y) pair in the vector space.

(Edit: Also added a `opacityStep` parameter, so the user can easily tweak how much difference of opacity they want. Read the first comment for more details)

### Naive implementation
The first naive approach is to change the VectorField function so that it creates a <path> tag for each vector with it's respective opacity. When implemented, this causes a severe amount of lag. So, we can't draw each vector individually without making the VectorField annoying to use. **This is a BAD solution.**

### Granularity implementation (what was implemented)
A great solution to this is to lump like-opacity vectors into the same <path> tag. We do this by creating "layers" representing different ranges in opacity. Each layer represents a certain opacity range: (0,0.2],(0.2,0.4],...(0.8,1.0]. It is currently set up so there is a granularity of 5 (e.i there are 5 layers), however this can be changed on line 31 (the sole parameter to `generateOpacityLaters` function). I found that 5 seems to be a good number. 10 also works, but it is slightly less smooth.

Now, as we go through the main loop of `fieldForRegion`, we find the layer that represents the given point (x,y) and add the vector drawing command to that layer's d' string. Then we simply create a path tag for each layer, and tada! We got a non-laggy opacity for the vectors.

One thing I changed: it use to create a path tag for each quadrant of the screen (I think?), but I did away with that to quarter the amount of path tags needed. I hope this is not problematic. This is really the biggest change to VectorField's functionality besides the new feature.

**This is a GOOD solution.** (I think)

### Testing
I just tested this by replacing the node module within another repo with my yarn built fork. So, I am not sure if there is a more rigorous or legitimate way to test it. Please test it yourself to ensure I didn't mess up!

### Documentation
I added docstrings to new functions I created in VectorField.tsx. I can add documentation to the website, once I figure out how to run the website locally...

### Results
I implemented this for my site https://physics.zawie.io (a physics simulation site). The following gif represents using the opacity feature on VectorFields for an electric field. It is significantly more chunky in the gif. In the live implementation it is not noticeably slower than the older version.
![VanishingFieldDemo-2](https://user-images.githubusercontent.com/15623191/94770001-47bd4300-0368-11eb-99e3-cacc04a02da5.gif)

The code for this implementation is this:
```javascript
<VectorField
        xy={(x, y) => {
          const maxMag = 0.25
          var v = vec.scale(chargeAtPoint([x,y]),0.5)
          if (vec.mag(v)>maxMag){
            v = vec.scale(vec.norm(v),maxMag)
          }
          return v
        }}
       opacity={(x,y) =>{
          var v = chargeAtPoint([x,y])
          var c = vec.mag(v);
          return Math.max(Math.min(c,1),0)
        }}
        step={0.5}
/>
```
Note: the opacity doesn't need to be between 0 and 1, it won't break the functionality, so you don't actually need the Min maxing on the return statement for opacity.

### Drawback
The opacity isn't handled dynamically. The user has to define the opacity and direction function themselves. I don't think there is a slick way of doing this without hampering the user's ability to customize the field sufficiently.

### Closing
This is a super important feature for VectorField. Without it, VectorFields can be impractical to use for sufficiently complicated fields.

This is my first pull request to an open source project! If you have any questions, concerns, or feedback, hit me up. 