### PR TITLE
Enable bumping points via the keyboard

### DIFF
--- a/.api-report/mafs.api.md
+++ b/.api-report/mafs.api.md
@@ -279,7 +279,7 @@ export interface UseMovablePoint {
 }
 
 // @public (undocumented)
-export function useMovablePoint([initialX, initialY]: Vector2, { constrain, color, transform }?: UseMovablePointArguments): UseMovablePoint;
+export function useMovablePoint(initialPoint: Vector2, { constrain, color, transform }?: UseMovablePointArguments): UseMovablePoint;
 
 // @public (undocumented)
 export interface UseMovablePointArguments {

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
   display: block;
   background: var(--mafs-bg);
   overflow: hidden;
+  -webkit-user-select: none;
   user-select: none;
   font-family: inherit;
   font-variant-numeric: tabular-nums;
@@ -32,11 +33,17 @@
   stroke: var(--mafs-fg);
 }
 
+.MafsWrapper,
+.MafsView .draggable-hitbox {
+  touch-action: none;
+}
+
 .MafsView .draggable {
   transition: r 0.2s ease, stroke-width 0.2s ease;
   stroke-width: 18px;
   cursor: grab;
   outline: 0 !important;
+  touch-action: none;
 
   color: hsl(0, 100%, 47%);
 }

--- a/src/interaction/MovablePoint.tsx
+++ b/src/interaction/MovablePoint.tsx
@@ -1,67 +1,104 @@
-import React, { useState } from "react"
-import * as vec from "vec-la"
 import { useDrag } from "@use-gesture/react"
+import React, { useMemo, useRef, useState } from "react"
+import invariant from "tiny-invariant"
+import * as vec from "vec-la"
+import { matrixInvert, range, Vector2 } from "../math"
 import { useScaleContext } from "../view/ScaleContext"
-import { Vector2 } from "../math"
+
+export type ConstraintFunction = (position: Vector2) => Vector2
 
 interface MovablePointProps {
-  x: number
-  y: number
-  onMovement: (props: { movement: Vector2; first: boolean }) => void
-  color?: string
+  point: Vector2
+  onMove: (point: Vector2) => void
+  transform: vec.Matrix
+  constrain: ConstraintFunction
+  color: string
 }
 
+/** @private */
 const MovablePoint: React.VFC<MovablePointProps> = ({
-  x,
-  y,
-  onMovement,
-  color = "var(--mafs-blue)",
+  point,
+  onMove,
+  transform,
+  constrain,
+  color,
 }) => {
-  const { scaleX, scaleY, xSpan, ySpan, inversePixelMatrix } = useScaleContext()
-  const [dragging, setDragging] = useState(false)
+  const { xSpan, ySpan, pixelMatrix, inversePixelMatrix } = useScaleContext()
+  const inverseTransform = useMemo(() => getInverseTransform(transform), [transform])
 
-  const bind = useDrag(
-    ({ event, down, movement, first }) => {
-      event?.stopPropagation()
-      setDragging(down)
-      onMovement({ movement: vec.transform(movement, inversePixelMatrix), first })
-    },
-    { eventOptions: { passive: false } }
-  )
+  const [dragging, setDragging] = useState(false)
+  const [displayX, displayY] = vec.transform(vec.transform(point, transform), pixelMatrix)
+
+  const pickup = useRef<Vector2>([0, 0])
+
+  const bind = useDrag(({ event, down, movement: pixelMovement, first }) => {
+    event?.stopPropagation()
+    setDragging(down)
+
+    if (first) pickup.current = vec.transform(point, transform)
+    if (vec.mag(pixelMovement) === 0) return
+
+    const movement = vec.transform(pixelMovement, inversePixelMatrix)
+    const newPoint = constrain(vec.transform(vec.add(pickup.current, movement), inverseTransform))
+
+    onMove(newPoint)
+  })
 
   function handleKeyDown(event: React.KeyboardEvent) {
-    const scale = event.altKey || event.metaKey || event.shiftKey ? 400 : 40
+    const small = event.altKey || event.metaKey || event.shiftKey
+
+    let span: number
+    let testDir: Vector2
 
     switch (event.key) {
       case "ArrowLeft":
+        span = xSpan
+        testDir = [-1, 0]
         event.preventDefault()
-        onMovement({ movement: [0, 0], first: true })
-        onMovement({ movement: [-xSpan / scale, 0], first: false })
         break
       case "ArrowRight":
-        onMovement({ movement: [0, 0], first: true })
-        onMovement({ movement: [xSpan / scale, 0], first: false })
+        span = xSpan
+        testDir = [1, 0]
         event.preventDefault()
         break
       case "ArrowUp":
-        onMovement({ movement: [0, 0], first: true })
-        onMovement({ movement: [0, ySpan / scale], first: false })
+        span = ySpan
+        testDir = [0, 1]
         event.preventDefault()
         break
       case "ArrowDown":
-        onMovement({ movement: [0, 0], first: true })
-        onMovement({ movement: [0, -ySpan / scale], first: false })
+        span = ySpan
+        testDir = [0, -1]
         event.preventDefault()
         break
+      default:
+        return
+    }
+
+    const divisions = small ? 200 : 50
+    const min = span / (divisions * 2)
+    const tests = range(span / divisions, span / 2, span / divisions)
+
+    for (const dx of tests) {
+      // Transform the test back into the point's coordinate system
+      const testMovement = vec.scale(testDir, dx)
+      const testPoint = constrain(
+        vec.transform(vec.add(vec.transform(point, transform), testMovement), inverseTransform)
+      )
+
+      if (vec.dist(testPoint, point) > min) {
+        onMove(testPoint)
+        break
+      }
     }
   }
 
   return (
-    <g {...bind()}>
-      <circle cx={scaleX(x)} cy={scaleY(y)} r={30} fill="transparent"></circle>
+    <g {...bind()} className="draggable-hitbox">
+      <circle cx={displayX} cy={displayY} r={30} fill="transparent"></circle>
       <circle
-        cx={scaleX(x)}
-        cy={scaleY(y)}
+        cx={displayX}
+        cy={displayY}
         r={6}
         fill={color}
         stroke={color}
@@ -72,6 +109,15 @@ const MovablePoint: React.VFC<MovablePointProps> = ({
       ></circle>
     </g>
   )
+}
+
+function getInverseTransform(transform: vec.Matrix) {
+  const invert = matrixInvert(transform)
+  invariant(
+    invert !== null,
+    "Could not invert transform matrix. Your movable point's constraint function might be degenerative (mapping 2D space to a line)."
+  )
+  return invert
 }
 
 export default MovablePoint

--- a/src/view/MafsView.tsx
+++ b/src/view/MafsView.tsx
@@ -112,7 +112,7 @@ const MafsView: React.FC<MafsViewProps> = ({
 
   return (
     <div
-      className="overflow-hidden w-auto"
+      className="MafsWrapper overflow-hidden w-auto"
       style={{ width: desiredCssWidth }}
       ref={ref}
       {...bind()}


### PR DESCRIPTION
Movable points need to be movable from the keyboard to accommodate people who are unable to use a mouse. Currently it's a bit naive: using the arrow keys attempts to move the point by a fixed amount. If you have a constraint function on your movable point, this fixed amount might not be enough to actually make the point "move".

This implementation uses a technique that attempts to find the smallest reasonable value that does make the point move, and bumps by that amount. The downside is that people's `constrain` functions should anticipate that they'll get called many times, and therefore probably shouldn't have side effects.