### PR TITLE
Move vec-la directly into mafs

### DIFF
--- a/docs/src/guide-examples/MovableCircle.tsx
+++ b/docs/src/guide-examples/MovableCircle.tsx
@@ -4,8 +4,8 @@ import {
   Circle,
   CartesianCoordinates,
   useMovablePoint,
+  vec,
 } from "mafs"
-import * as vec from "vec-la"
 
 export default function MovableCircle() {
   const pointOnCircle = useMovablePoint([

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -57,3 +57,5 @@ export { useStopwatch } from "./animation/useStopwatch"
 export type { Stopwatch, StopwatchArguments } from "./animation/useStopwatch"
 
 export type { Interval, Vector2 } from "./math"
+
+export { default as vec } from "./vec"

--- a/src/interaction/useMovablePoint.tsx
+++ b/src/interaction/useMovablePoint.tsx
@@ -1,10 +1,8 @@
 import * as React from "react"
-import * as vec from "vec-la"
+import vec, { Matrix } from "../vec"
 import { Theme } from "../display/Theme"
 import { Vector2 } from "../math"
 import { MovablePoint } from "./MovablePoint"
-
-const identity = vec.matrixBuilder().get()
 
 export type ConstraintFunction = (position: Vector2) => Vector2
 
@@ -15,7 +13,7 @@ export interface UseMovablePointArguments {
    * Transform the point's movement and constraints by a transformation matrix. You can use `vec-la`
    * to build up such a matrix.
    */
-  transform?: vec.Matrix
+  transform?: Matrix
 
   /**
    * Constrain the point to only horizontal movement, vertical movement, or mapped movement.
@@ -36,7 +34,7 @@ export interface UseMovablePoint {
 
 export function useMovablePoint(
   initialPoint: Vector2,
-  { constrain, color = Theme.pink, transform = identity }: UseMovablePointArguments = {}
+  { constrain, color = Theme.pink, transform = vec.identity }: UseMovablePointArguments = {}
 ): UseMovablePoint {
   const [initialX, initialY] = initialPoint
   const [point, setPoint] = React.useState<Vector2>(initialPoint)

--- a/src/la.ts
+++ b/src/la.ts
@@ -1,0 +1,81 @@
+export type Vector2 = [x: number, y: number]
+/** An array representing a 3×3 matrix. */
+export type Matrix = [number, number, number, number, number, number, number, number, number]
+
+/**
+ * A series of 2D linear algebra helpers ("la" is short for linear algebra).
+ *
+ * Adapted from [@francisrstokes/vec-la](https://github.com/francisrstokes/vec-la)
+ */
+const la = {
+  /** Adds two vectors */
+  add(a: Vector2, b: Vector2): Vector2 {
+    return [a[0] + b[0], a[1] + b[1]]
+  },
+
+  /** Subtracts two vectors (a - b) */
+  sub(a: Vector2, b: Vector2): Vector2 {
+    return [a[0] - b[0], a[1] - b[1]]
+  },
+
+  /** Computes the scalar magnitude of `v` */
+  mag(v: Vector2): number {
+    return Math.sqrt(v[0] * v[0] + v[1] * v[1])
+  },
+
+  /**
+   * Computes the squared magnitude of `v`.
+   *
+   * This is useful for comparing magnitudes of vectors, since it is faster than
+   * computing the true magnitude.
+   */
+  magSq(v: Vector2): number {
+    return v[0] * v[0] + v[1] * v[1]
+  },
+
+  /**
+   * Normalizes `v` to a unit vector.
+   *
+   * If `v` is the zero vector, returns the zero vector.
+   */
+  norm(v: Vector2): Vector2 {
+    const mag = la.mag(v)
+
+    if (mag === 0) return [0, 0]
+    return [v[0] / mag, v[1] / mag]
+  },
+
+  scale(v: Vector2, scalar: number): Vector2 {
+    return [v[0] * scalar, v[1] * scalar]
+  },
+
+  /** Computes the linear interpolation between `a` and `b` */
+  lerp(a: Vector2, b: Vector2, t: number): Vector2 {
+    return la.add(a, la.scale(la.sub(b, a), t))
+  },
+
+  /** Transforms the vector `v` by the matrix `m` */
+  trans(v: Vector2, m: Matrix): Vector2 {
+    return [
+      // prettier-ignore
+      m[0] * v[0] + m[1] * v[1] + m[2],
+      m[3] * v[0] + m[4] * v[1] + m[5],
+    ]
+  },
+
+  matrixMult(m1: Matrix, m2: Matrix): Matrix {
+    return [
+      m1[0] * m2[0] + m1[1] * m2[3] + m1[2] * m2[6],
+      m1[0] * m2[1] + m1[1] * m2[4] + m1[2] * m2[7],
+      m1[0] * m2[2] + m1[1] * m2[5] + m1[2] * m2[8],
+      m1[3] * m2[0] + m1[4] * m2[3] + m1[5] * m2[6],
+      m1[3] * m2[1] + m1[4] * m2[4] + m1[5] * m2[7],
+      m1[3] * m2[2] + m1[4] * m2[5] + m1[5] * m2[8],
+      m1[6] * m2[0] + m1[7] * m2[3] + m1[8] * m2[6],
+      m1[6] * m2[1] + m1[7] * m2[4] + m1[8] * m2[7],
+      m1[6] * m2[2] + m1[7] * m2[5] + m1[8] * m2[8],
+    ]
+  },
+}
+
+export default la

--- a/src/math.ts
+++ b/src/math.ts
@@ -1,4 +1,4 @@
-import { Matrix } from "vec-la"
+import { Matrix } from "./vec"
 
 export type Vector2 = [x: number, y: number]
 export type Interval = [min: number, max: number]

--- a/src/vec.ts
+++ b/src/vec.ts
@@ -3,11 +3,11 @@ export type Vector2 = [x: number, y: number]
 export type Matrix = [number, number, number, number, number, number, number, number, number]
 
 /**
- * A series of 2D linear algebra helpers ("la" is short for linear algebra).
+ * A series of 2D linear algebra helpers.
  *
- * Adapted from [@francisrstokes/vec-la](https://github.com/francisrstokes/vec-la)
+ * @note Some code taken from [@francisrstokes/vec-la](https://github.com/francisrstokes/vec-la).
  */
-const la = {
+const vec = {
   /** Adds two vectors */
   add(a: Vector2, b: Vector2): Vector2 {
     return [a[0] + b[0], a[1] + b[1]]
@@ -39,19 +39,20 @@ const la = {
    * If `v` is the zero vector, returns the zero vector.
    */
   norm(v: Vector2): Vector2 {
-    const mag = la.mag(v)
+    const mag = vec.mag(v)
 
     if (mag === 0) return [0, 0]
     return [v[0] / mag, v[1] / mag]
   },
 
+  /** Scales `v` by a scalar quantity */
   scale(v: Vector2, scalar: number): Vector2 {
     return [v[0] * scalar, v[1] * scalar]
   },
 
   /** Computes the linear interpolation between `a` and `b` */
   lerp(a: Vector2, b: Vector2, t: number): Vector2 {
-    return la.add(a, la.scale(la.sub(b, a), t))
+    return vec.add(a, vec.scale(vec.sub(b, a), t))
   },
 
   /** Transforms the vector `v` by the matrix `m` */
@@ -61,6 +62,63 @@ const la = {
       m[0] * v[0] + m[1] * v[1] + m[2],
       m[3] * v[0] + m[4] * v[1] + m[5],
     ]
+  },
+
+  /** Computes the midpoint of `v1` and `v2` */
+  midpoint(v1: Vector2, v2: Vector2): Vector2 {
+    return vec.scale(vec.add(v1, v2), 0.5)
+  },
+
+  /** Computes the dot product of `v1` and `v2` */
+  dot(v1: Vector2, v2: Vector2): number {
+    return v1[0] * v2[0] + v1[1] * v2[1]
+  },
+
+  /** Computes the determinant of 3x3 matrix `m` */
+  det(m: Matrix): number {
+    return m[0] * m[4] - m[1] * m[3] + m[2] * (m[1] * m[5] - m[2] * m[4])
+  },
+
+  /** Compute the distance between `v1` and `v2` */
+  dist(v1: Vector2, v2: Vector2): number {
+    return vec.mag(vec.sub(v1, v2))
+  },
+
+  /** Inverts `m`, returning `null` if the matrix cannot be inverted */
+  invert(m: Matrix): Matrix | null {
+    const out: Matrix = new Array(9) as Matrix
+
+    const a00 = m[0],
+      a01 = m[1],
+      a02 = m[2]
+    const a10 = m[3],
+      a11 = m[4],
+      a12 = m[5]
+    const a20 = m[6],
+      a21 = m[7],
+      a22 = m[8]
+
+    const b01 = a22 * a11 - a12 * a21
+    const b11 = -a22 * a10 + a12 * a20
+    const b21 = a21 * a10 - a11 * a20
+
+    // Calculate the determinant
+    let det = vec.det(m)
+
+    if (Math.abs(det) <= 1e-12) return null
+    det = 1.0 / det
+
+    out[0] = b01 * det
+    out[1] = (-a22 * a01 + a02 * a21) * det
+    out[2] = (a12 * a01 - a02 * a11) * det
+    out[3] = b11 * det
+    out[4] = (a22 * a00 - a02 * a20) * det
+    out[5] = (-a12 * a00 + a02 * a10) * det
+    out[6] = b21 * det
+    out[7] = (-a21 * a00 + a01 * a20) * det
+    out[8] = (a11 * a00 - a01 * a10) * det
+
+    return out
   },
 
   matrixMult(m1: Matrix, m2: Matrix): Matrix {
@@ -78,4 +136,4 @@ const la = {
   },
 }
 
-export default la
+export default vec

--- a/src/view/MafsView.tsx
+++ b/src/view/MafsView.tsx
@@ -3,7 +3,7 @@ import CoordinateContext, { CoordinateContextShape } from "./CoordinateContext"
 import PaneManager from "./PaneManager"
 import MapContext from "./MapContext"
 import useResizeObserver from "use-resize-observer"
-import * as vec from "vec-la"
+import vec from "../vec"
 
 import { useGesture } from "@use-gesture/react"
 import ScaleContext, { ScaleContextShape } from "./ScaleContext"

--- a/src/view/ScaleContext.tsx
+++ b/src/view/ScaleContext.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import invariant from "tiny-invariant"
 
-import type { Matrix } from "vec-la"
+import type { Matrix } from "../vec"
 
 export interface ScaleContextShape {
   scaleX: (x: number) => number


### PR DESCRIPTION
I've LOVED using [`vec-la`](https://www.npmjs.com/package/vec-la) to build Mafs. So much easier than other tools. But it doesn't ship with types and I can't easily extend it.

I want Mafs to be more of a framework for math visualizations—not just a frontend library. So I'm integrating vec-la directly into Mafs. I'll probably add more geometry helpers over time, similar to how pts.js provides a bunch of geometry solvers.