### PR TITLE
Remove runtime dependency on lodash

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -4,7 +4,6 @@ module.exports = {
       width: 500,
       height: 500,
     },
-    args: ["--font-render-hinting=none", "--disable-gpu", "--force-device-scale-factor=1"],
   },
   browserContext: "default",
 }

--- a/package.json
+++ b/package.json
@@ -21,16 +21,10 @@
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@microsoft/api-extractor": "^7.18.7",
-    "@types/classnames": "^2.2.10",
     "@types/expect-puppeteer": "^4.4.6",
     "@types/jest": "^27.0.1",
     "@types/jest-environment-puppeteer": "^4.4.1",
     "@types/jest-image-snapshot": "^4.3.1",
-    "@types/lodash.clamp": "^4.0.6",
-    "@types/lodash.memoize": "^4.1.6",
-    "@types/lodash.range": "^3.2.6",
-    "@types/lodash.round": "^4.0.6",
-    "@types/lodash.sumby": "^4.6.6",
     "@types/node": "^14",
     "@types/puppeteer": "^5.4.4",
     "@types/react": "^17.0.19",
@@ -49,7 +43,6 @@
     "puppeteer": "^10.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "resize-observer-polyfill": "^1.5.1",
     "ts-jest": "^27.0.5",
     "typescript": "^4.4.2"
   },
@@ -58,10 +51,8 @@
     "react-dom": ">=16.8"
   },
   "dependencies": {
-    "lodash.clamp": "^4.0.3",
-    "lodash.range": "^3.2.0",
-    "lodash.round": "^4.0.4",
     "react-use-gesture": "^7.0.16",
+    "resize-observer-polyfill": "^1.5.1",
     "tiny-invariant": "^1.1.0",
     "use-resize-observer": "^6.1.0",
     "vec-la": "^1.5.0"

--- a/src/display/FunctionGraph/OfX.tsx
+++ b/src/display/FunctionGraph/OfX.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo } from "react"
-import round from "lodash.round"
+import { round } from "../../math"
 import { usePaneContext } from "../../view/PaneManager"
 import { Stroked } from "../../display/Theme"
 import { useScaleContext } from "../../view/ScaleContext"

--- a/src/display/Line/Segment.tsx
+++ b/src/display/Line/Segment.tsx
@@ -1,9 +1,8 @@
 import React from "react"
 import * as vec from "vec-la"
-import { round } from "../../math"
 import { Stroked, theme } from "../../display/Theme"
 import { useScaleContext } from "../../view/ScaleContext"
-import { Vector2 } from "../../math"
+import { round, Vector2 } from "../../math"
 
 export interface SegmentProps extends Stroked {
   point1: Vector2

--- a/src/display/Line/Segment.tsx
+++ b/src/display/Line/Segment.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import * as vec from "vec-la"
-import round from "lodash.round"
+import { round } from "../../math"
 import { Stroked, theme } from "../../display/Theme"
 import { useScaleContext } from "../../view/ScaleContext"
 import { Vector2 } from "../../math"

--- a/src/display/Line/ThroughPoints.tsx
+++ b/src/display/Line/ThroughPoints.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import * as vec from "vec-la"
-import round from "lodash.round"
+import { round } from "../../math"
 import { Stroked, theme } from "../../display/Theme"
 import { useScaleContext } from "../../view/ScaleContext"
 import { Vector2 } from "../../math"

--- a/src/display/Line/ThroughPoints.tsx
+++ b/src/display/Line/ThroughPoints.tsx
@@ -1,9 +1,8 @@
 import React from "react"
 import * as vec from "vec-la"
-import { round } from "../../math"
 import { Stroked, theme } from "../../display/Theme"
 import { useScaleContext } from "../../view/ScaleContext"
-import { Vector2 } from "../../math"
+import { round, Vector2 } from "../../math"
 
 export interface ThroughPointsProps extends Stroked {
   point1: Vector2

--- a/src/display/VectorField.tsx
+++ b/src/display/VectorField.tsx
@@ -1,8 +1,7 @@
-import clamp from "lodash.clamp"
 import React from "react"
 import * as vec from "vec-la"
 
-import { Vector2 } from "../math"
+import { clamp, Vector2 } from "../math"
 import { usePaneContext } from "../view/PaneManager"
 import { useScaleContext } from "../view/ScaleContext"
 import { theme } from "./Theme"

--- a/src/math.test.ts
+++ b/src/math.test.ts
@@ -1,0 +1,50 @@
+import { clamp, range, round } from "./math"
+
+describe("clamp", () => {
+  it("clamps a number between two values", () => {
+    expect(clamp(0, 1, 2)).toBe(1)
+    expect(clamp(10, 0, 1)).toBe(1)
+    expect(clamp(-10, 0, 1)).toBe(0)
+  })
+})
+
+describe("range", () => {
+  it("generates a range", () => {
+    expect(range(0, 10)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  })
+
+  it("generates a range with a step", () => {
+    expect(range(0, 10, 2)).toEqual([0, 2, 4, 6, 8, 10])
+  })
+
+  it("handles when the step introduces weird floating point errors", () => {
+    const problematicRange = range(0, 0.6, 0.2)
+    expect(problematicRange[0]).toEqual(0)
+    expect(problematicRange[1]).toBeCloseTo(0.2)
+    expect(problematicRange[2]).toBeCloseTo(0.4)
+    expect(problematicRange[3]).toEqual(0.6)
+  })
+})
+
+describe("round", () => {
+  it("rounds toward zero in the trivial case", () => {
+    expect(round(0.2)).toEqual(0)
+    expect(round(-0.2)).toEqual(-0)
+
+    expect(round(0.12, 1)).toEqual(0.1)
+    expect(round(-0.12, 1)).toEqual(-0.1)
+  })
+
+  it("rounds away from zero in the trivial case", () => {
+    expect(round(0.8)).toEqual(1)
+    expect(round(-0.8)).toEqual(-1)
+
+    expect(round(0.08, 1)).toEqual(0.1)
+    expect(round(-0.08, 1)).toEqual(-0.1)
+  })
+
+  it("rounds away from zero with 0.5, and toward zero with -0.5 (JS quirk, but acceptable for internal use)", () => {
+    expect(round(0.5)).toEqual(1)
+    expect(round(-0.5)).toEqual(-0)
+  })
+})

--- a/src/math.ts
+++ b/src/math.ts
@@ -3,6 +3,24 @@ import { Matrix } from "vec-la"
 export type Vector2 = [x: number, y: number]
 export type Interval = [min: number, max: number]
 
+export function round(value: number, precision = 0): number {
+  const multiplier = Math.pow(10, precision || 0)
+  return Math.round(value * multiplier) / multiplier
+}
+
+export function range(min: number, max: number, step = 1): number[] {
+  const result = []
+  for (let i = min; i < max; i += step) {
+    result.push(i)
+  }
+  result.push(max)
+  return result
+}
+
+export function clamp(number: number, min: number, max: number): number {
+  return Math.min(Math.max(number, min), max)
+}
+
 /** Inverts a 3x3 matrix */
 export function matrixInvert(matrix: Matrix): Matrix | null {
   const a = matrix

--- a/src/math.ts
+++ b/src/math.ts
@@ -10,7 +10,7 @@ export function round(value: number, precision = 0): number {
 
 export function range(min: number, max: number, step = 1): number[] {
   const result = []
-  for (let i = min; i < max; i += step) {
+  for (let i = min; i < max - step / 2; i += step) {
     result.push(i)
   }
   result.push(max)

--- a/src/origin/CartesianCoordinates.tsx
+++ b/src/origin/CartesianCoordinates.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo } from "react"
 import GridPattern from "./GridPattern"
-import range from "lodash.range"
+import { range, round } from "../math"
 import { usePaneContext } from "../view/PaneManager"
-import round from "lodash.round"
 import { useScaleContext } from "../view/ScaleContext"
 
 export type LabelMaker = (value: number) => number | string

--- a/src/origin/GridPattern.tsx
+++ b/src/origin/GridPattern.tsx
@@ -1,5 +1,5 @@
-import range from "lodash.range"
 import React from "react"
+import { range } from "../math"
 import { useScaleContext } from "../view/ScaleContext"
 
 interface GridPatternProps {

--- a/src/view/MafsView.tsx
+++ b/src/view/MafsView.tsx
@@ -3,12 +3,11 @@ import CoordinateContext, { CoordinateContextShape } from "./CoordinateContext"
 import PaneManager from "./PaneManager"
 import MapContext from "./MapContext"
 import useResizeObserver from "use-resize-observer"
-import { round } from "../math"
 import * as vec from "vec-la"
 
 import { useGesture } from "react-use-gesture"
 import ScaleContext, { ScaleContextShape } from "./ScaleContext"
-import { Interval, Vector2 } from "../math"
+import { round, Interval, Vector2 } from "../math"
 
 export interface MafsViewProps {
   width?: number | string

--- a/src/view/MafsView.tsx
+++ b/src/view/MafsView.tsx
@@ -3,7 +3,7 @@ import CoordinateContext, { CoordinateContextShape } from "./CoordinateContext"
 import PaneManager from "./PaneManager"
 import MapContext from "./MapContext"
 import useResizeObserver from "use-resize-observer"
-import round from "lodash.round"
+import { round } from "../math"
 import * as vec from "vec-la"
 
 import { useGesture } from "react-use-gesture"

--- a/src/view/PaneManager.tsx
+++ b/src/view/PaneManager.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useMemo } from "react"
 import { useCoordinateContext } from "./CoordinateContext"
-import range from "lodash.range"
-import { Interval } from "../math"
+import { range, Interval } from "../math"
 
 interface PaneContextShape {
   xPanes: Interval[]

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,31 +833,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
-"@types/lodash.clamp@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.clamp/-/lodash.clamp-4.0.6.tgz#ca51ac61e11c6c6109638f44179abb97031619cb"
-  integrity sha512-+Rn39PbxYSbFFVXGEpw5t7EM8clP4P3d5rtbBFJYZUsgyWO1S0EYiNf+vKc2dRUy5eSI+oAVVlpgMF0vJcMUtA==
-  dependencies:
-    "@types/lodash" "*"
-
 "@types/lodash.memoize@^4.1.6":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.memoize/-/lodash.memoize-4.1.6.tgz#3221f981790a415cab1a239f25c17efd8b604c23"
   integrity sha512-mYxjKiKzRadRJVClLKxS4wb3Iy9kzwJ1CkbyKiadVxejnswnRByyofmPMscFKscmYpl36BEEhCMPuWhA1R/1ZQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.range@^3.2.6":
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.range/-/lodash.range-3.2.6.tgz#82e0afe2cbc77698a57a21b9f14cfd22cf547e9f"
-  integrity sha512-bofMTb/7zteggVbeQfMp5iMd1Dar0txmq/i2HEWgrRabF4HxZsyHeny9YktvUGpgkk2m1A4qEkUovVWpbFDYRg==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash.round@^4.0.6":
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.round/-/lodash.round-4.0.6.tgz#dddd13d478baffaef66b5b65b88978140253fad3"
-  integrity sha512-4/fs+g0BRnsJZMg0Nl5zHbx4rvo2J6KeDBPsgNvDZ1WKl4/wPOn3yiA7VURP+W0ZgUUQHEpEuLCFRfdW/h5ONg==
   dependencies:
     "@types/lodash" "*"
 
@@ -3295,11 +3274,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.clamp@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/lodash.clamp/-/lodash.clamp-4.0.3.tgz#5c24bedeeeef0753560dc2b4cb4671f90a6ddfaa"
-  integrity sha1-XCS+3u7vB1NWDcK0y0Zx+Qpt36o=
-
 lodash.clonedeep@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
@@ -3319,16 +3293,6 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.range@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.range/-/lodash.range-3.2.0.tgz#f461e588f66683f7eadeade513e38a69a565a15d"
-  integrity sha1-9GHliPZmg/fq3q3lE+OKaaVloV0=
-
-lodash.round@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/lodash.round/-/lodash.round-4.0.4.tgz#101b6ba5c6cecc998f2abbe80b6029affd25d262"
-  integrity sha1-EBtrpcbOzJmPKrvoC2Apr/0l0mI=
 
 lodash.truncate@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
No more `lodash.clamp`, `lodash.range`, or `lodash.round` (all of which are surprisingly large!).