### PR TITLE
Add a devcontainer for OOTB Codespaces + Puppeteer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
 ARG VARIANT="16"
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#   && apt-get -y install --no-install-recommends
+
+RUN apt-get update && \
+  # Install Puppeteer's dependencies
+  apt-get install -y ca-certificates fonts-liberation libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+ARG VARIANT="16"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#   && apt-get -y install --no-install-recommends

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,10 @@
 {
-  "build": { "dockerfile": "Dockerfile" },
-  "appPort": 8000
+  "name": "Node.js",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": { "VARIANT": "16" }
+  },
+  "settings": {},
+  "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "Orta.vscode-jest"],
+  "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "build": { "dockerfile": "Dockerfile" },
+  "appPort": 8000
+}

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+16

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -4,6 +4,7 @@ module.exports = {
       width: 500,
       height: 500,
     },
+    args: ["--no-sandbox"],
   },
   browserContext: "default",
 }


### PR DESCRIPTION
Microsoft's default devcontainer doesn't seem to support the latest Puppeteer out of the box. This adds support.

microsoft/vscode-dev-containers#710 adds Puppeteer support to the universal devcontainer, not to the node container, and it seems like enough has changed with the latest Puppeteer that it doesn't work at all without installing a few extra packages.