### PR TITLE
Expose MovablePoint and setPoint

### DIFF
--- a/.api-report/mafs.api.md
+++ b/.api-report/mafs.api.md
@@ -49,6 +49,9 @@ export interface CircleProps extends Filled {
 export type ConstraintFunction = (position: Vector2) => Vector2;
 
 // @public (undocumented)
+export type _ConstraintFunction1 = (position: Vector2) => Vector2;
+
+// @public (undocumented)
 export const Ellipse: React_2.VFC<EllipseProps>;
 
 // @public (undocumented)
@@ -116,6 +119,19 @@ export interface MafsViewProps {
     xAxisExtent?: Interval;
     // (undocumented)
     yAxisExtent?: Interval;
+}
+
+// @public (undocumented)
+export const MovablePoint: React_2.VFC<MovablePointProps>;
+
+// @public (undocumented)
+export interface MovablePointProps {
+    // (undocumented)
+    color?: string;
+    constrain?: _ConstraintFunction1;
+    onMove: (point: Vector2) => void;
+    point: Vector2;
+    transform?: vec.Matrix;
 }
 
 // @public (undocumented)
@@ -273,6 +289,8 @@ export interface UseMovablePoint {
     element: React_2.ReactElement;
     // (undocumented)
     point: Vector2;
+    // (undocumented)
+    setPoint: (point: Vector2) => void;
     // (undocumented)
     x: number;
     // (undocumented)

--- a/docs/src/components/Advanced.tsx
+++ b/docs/src/components/Advanced.tsx
@@ -3,6 +3,7 @@ import React from "react"
 export const Advanced: React.VFC = () => {
   return (
     <span className="text-xs py-1 px-3 rounded-full bg-blue-700 text-white uppercase font-bold">
+      <span className="sr-only">the following section is</span>
       Advanced
     </span>
   )

--- a/docs/src/components/Advanced.tsx
+++ b/docs/src/components/Advanced.tsx
@@ -1,0 +1,9 @@
+import React from "react"
+
+export const Advanced: React.VFC = () => {
+  return (
+    <span className="text-xs py-1 px-3 rounded-full bg-blue-700 text-white uppercase font-bold">
+      Advanced
+    </span>
+  )
+}

--- a/docs/src/guide-examples/display/DynamicMovablePoints.tsx
+++ b/docs/src/guide-examples/display/DynamicMovablePoints.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React from "react"
 // prettier-ignore
 import { Mafs, CartesianCoordinates, MovablePoint, Vector2, useMovablePoint, Line, Theme } from "mafs"
 import * as vec from "vec-la"

--- a/docs/src/guide-examples/display/DynamicMovablePoints.tsx
+++ b/docs/src/guide-examples/display/DynamicMovablePoints.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react"
+// prettier-ignore
+import { Mafs, CartesianCoordinates, MovablePoint, Vector2, useMovablePoint, Line, Theme } from "mafs"
+import * as vec from "vec-la"
+
+export default function DynamicMovablePoints() {
+  const startPoint = useMovablePoint([-3, -1])
+  const endPoint = useMovablePoint([3, 1])
+
+  const length = vec.dist(startPoint.point, endPoint.point)
+  const numPointsInBetween = length
+
+  function shift(shiftBy: Vector2) {
+    startPoint.setPoint(vec.add(startPoint.point, shiftBy))
+    endPoint.setPoint(vec.add(endPoint.point, shiftBy))
+  }
+
+  return (
+    <Mafs>
+      <CartesianCoordinates />
+
+      <Line.Segment
+        point1={startPoint.point}
+        point2={endPoint.point}
+      />
+
+      {new Array(Math.round(numPointsInBetween))
+        .fill(0)
+        .map((_, i) => {
+          if (i === 0 || i === numPointsInBetween)
+            return null
+
+          const point = vec.towards(
+            startPoint.point,
+            endPoint.point,
+            i / numPointsInBetween
+          )
+          return (
+            <MovablePoint
+              key={i}
+              point={point}
+              color={Theme.blue}
+              onMove={(newPoint) => {
+                shift(vec.sub(newPoint, point))
+              }}
+            />
+          )
+        })}
+
+      {startPoint.element}
+      {endPoint.element}
+    </Mafs>
+  )
+}

--- a/docs/src/pages/guides/interaction/movable-points.tsx
+++ b/docs/src/pages/guides/interaction/movable-points.tsx
@@ -12,7 +12,6 @@ import SnapPoint from "guide-examples/SnapPoint"
 import SnapPointSource from "!raw-loader!guide-examples/SnapPoint"
 import MovableEllipse from "guide-examples/MovableEllipse"
 import MovableEllipseSource from "!raw-loader!guide-examples/MovableEllipse"
-import Note from "components/Note"
 import { Advanced } from "components/Advanced"
 
 export const frontmatter: Guide = {

--- a/docs/src/pages/guides/interaction/movable-points.tsx
+++ b/docs/src/pages/guides/interaction/movable-points.tsx
@@ -6,10 +6,14 @@ import CodeAndExample from "components/CodeAndExample"
 
 import PointsAlongFunction from "guide-examples/display/PointsAlongFunction"
 import PointsAlongFunctionSource from "!raw-loader!guide-examples/display/PointsAlongFunction"
+import DynamicMovablePoints from "guide-examples/display/DynamicMovablePoints"
+import DynamicMovablePointsSource from "!raw-loader!guide-examples/display/DynamicMovablePoints"
 import SnapPoint from "guide-examples/SnapPoint"
 import SnapPointSource from "!raw-loader!guide-examples/SnapPoint"
 import MovableEllipse from "guide-examples/MovableEllipse"
 import MovableEllipseSource from "!raw-loader!guide-examples/MovableEllipse"
+import Note from "components/Note"
+import { Advanced } from "components/Advanced"
 
 export const frontmatter: Guide = {
   title: "Movable points",
@@ -86,6 +90,22 @@ const Stopwatch: React.VFC = () => (
     </p>
 
     <CodeAndExample component={<MovableEllipse />} source={MovableEllipseSource} />
+
+    <h2 className="flex flex-col gap-1">
+      <div>
+        <Advanced />
+      </div>
+      <span>Using MovableHook directly</span>
+    </h2>
+
+    <p>
+      <code>useMovablePoint</code> is a hook that helps you instantiate and manage the state of a
+      <code>MovablePoint</code>. However, if need be, you can also use <code>MovablePoint</code>{" "}
+      directly. This can be useful if you need to work with a dynamic number of movable points
+      (since the React "rules of hooks" ban you from dynamically calling hooks).
+    </p>
+
+    <CodeAndExample component={<DynamicMovablePoints />} source={DynamicMovablePointsSource} />
   </GuidesLayout>
 )
 

--- a/docs/src/pages/guides/interaction/movable-points.tsx
+++ b/docs/src/pages/guides/interaction/movable-points.tsx
@@ -94,7 +94,7 @@ const Stopwatch: React.VFC = () => (
       <div>
         <Advanced />
       </div>
-      <span>Using MovableHook directly</span>
+      <span>Using MovablePoint directly</span>
     </h2>
 
     <p>

--- a/docs/src/styles/base.css
+++ b/docs/src/styles/base.css
@@ -41,7 +41,7 @@
 
   p code,
   ul code {
-    @apply rounded-sm bg-gray-200 p-1 text-sm;
+    @apply rounded-md bg-gray-200 py-1 px-2 text-sm;
   }
 
   :focus {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,6 +43,7 @@ export type { TextProps, CardinalDirection } from "./display/Text"
 export { theme as Theme } from "./display/Theme"
 export type { Filled, Stroked } from "./display/Theme"
 
+export { default as MovablePoint, MovablePointProps } from "./interaction/MovablePoint"
 export { default as useMovablePoint } from "./interaction/useMovablePoint"
 export type {
   ConstraintFunction,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,9 @@ export type { TextProps, CardinalDirection } from "./display/Text"
 export { theme as Theme } from "./display/Theme"
 export type { Filled, Stroked } from "./display/Theme"
 
-export { default as MovablePoint, MovablePointProps } from "./interaction/MovablePoint"
+export { default as MovablePoint } from "./interaction/MovablePoint"
+export type { MovablePointProps } from "./interaction/MovablePoint"
+
 export { default as useMovablePoint } from "./interaction/useMovablePoint"
 export type {
   ConstraintFunction,

--- a/src/interaction/MovablePoint.tsx
+++ b/src/interaction/MovablePoint.tsx
@@ -9,16 +9,27 @@ import { useScaleContext } from "../view/ScaleContext"
 export type ConstraintFunction = (position: Vector2) => Vector2
 
 export interface MovablePointProps {
+  /** The current position (`[x, y]`) of the point. */
   point: Vector2
+  /** A callback that is called as the user moves the point. */
   onMove: (point: Vector2) => void
+  /**
+   * Transform the point's movement and constraints by a transformation matrix. You can use `vec-la`
+   * to build up such a matrix.
+   */
   transform?: vec.Matrix
+  /**
+   * Constrain the point to only horizontal movement, vertical movement, or mapped movement.
+   *
+   * In mapped movement mode, you must provide a function that maps the user's attempted position
+   * (x, y) to the position the point should "snap" to.
+   */
   constrain?: ConstraintFunction
   color?: string
 }
 
 const identity = vec.matrixBuilder().get()
 
-/** @private */
 const MovablePoint: React.VFC<MovablePointProps> = ({
   point,
   onMove,
@@ -118,7 +129,7 @@ function getInverseTransform(transform: vec.Matrix) {
   const invert = matrixInvert(transform)
   invariant(
     invert !== null,
-    "Could not invert transform matrix. Your movable point's constraint function might be degenerative (mapping 2D space to a line)."
+    "Could not invert transform matrix. Your movable point's transformation matrix might be degenerative (mapping 2D space to a line)."
   )
   return invert
 }

--- a/src/interaction/MovablePoint.tsx
+++ b/src/interaction/MovablePoint.tsx
@@ -1,27 +1,30 @@
 import { useDrag } from "@use-gesture/react"
 import React, { useMemo, useRef, useState } from "react"
 import invariant from "tiny-invariant"
+import { theme } from "../display/Theme"
 import * as vec from "vec-la"
 import { matrixInvert, range, Vector2 } from "../math"
 import { useScaleContext } from "../view/ScaleContext"
 
 export type ConstraintFunction = (position: Vector2) => Vector2
 
-interface MovablePointProps {
+export interface MovablePointProps {
   point: Vector2
   onMove: (point: Vector2) => void
-  transform: vec.Matrix
-  constrain: ConstraintFunction
-  color: string
+  transform?: vec.Matrix
+  constrain?: ConstraintFunction
+  color?: string
 }
+
+const identity = vec.matrixBuilder().get()
 
 /** @private */
 const MovablePoint: React.VFC<MovablePointProps> = ({
   point,
   onMove,
-  transform,
-  constrain,
-  color,
+  constrain = (point) => point,
+  color = theme.pink,
+  transform = identity,
 }) => {
   const { xSpan, ySpan, pixelMatrix, inversePixelMatrix } = useScaleContext()
   const inverseTransform = useMemo(() => getInverseTransform(transform), [transform])

--- a/src/interaction/useMovablePoint.tsx
+++ b/src/interaction/useMovablePoint.tsx
@@ -31,6 +31,7 @@ export interface UseMovablePoint {
   y: number
   point: Vector2
   element: React.ReactElement
+  setPoint: (point: Vector2) => void
 }
 
 function useMovablePoint(
@@ -69,6 +70,7 @@ function useMovablePoint(
     y,
     point: [x, y],
     element,
+    setPoint,
   }
 }
 


### PR DESCRIPTION
I noticed that @dd-jonas made a fork that added a `useMovablePoints` hook, so I wanted to help solve the problem of "how to control multiple points". I'm not going to introduce a similar hook for now (though perhaps down the road), but what I will do is make it easier to support multiple movable points by directly exposing the `MovablePoint` component to users.

This also adds a new section to the docs to cover using MovablePoint directly (the typo in this screenshot is fixed in code already):

<img width="587" alt="" src="https://user-images.githubusercontent.com/1724000/145743319-fe87cb06-d1ff-40e4-b6a8-02b2fba752ab.png">
