### PR TITLE
Swap x and y in atan2 call

### DIFF
--- a/docs/src/guide-examples/display/vectors/VectorExample.tsx
+++ b/docs/src/guide-examples/display/vectors/VectorExample.tsx
@@ -7,7 +7,7 @@ export default function VectorExample() {
   const tip = useMovablePoint([0.4, 0.6])
 
   const vec1 = tip.point
-  const angle = Math.PI / 2 - Math.atan2(tip.x, tip.y)
+  const angle = Math.PI / 2 - Math.atan2(tip.y, tip.x)
   const vec2 = vec.add(vec1, vec.rotate(vec1, angle))
   const vec3 = vec.add(vec1, vec.rotate(vec2, -2 * angle))
 


### PR DESCRIPTION
Of course this is an arbitrary example so it doesn't really matter, BUT I think it makes sense to pass `x` and `y` in the proper order to `atan2` for anyone using this example as a starting point for their own investigations.