### PR TITLE
fix: mobile code example, code not show all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .api-report/temp
 __diff_output__
 .parcel-cache
+.idea

--- a/docs/components/CodeAndExample.tsx
+++ b/docs/components/CodeAndExample.tsx
@@ -56,6 +56,7 @@ function CodeAndExample({
             md:rounded-b-lg
             refractor-highlight
             overflow-clip
+            overflow-x-scroll 
             ${collapsible ? "pb-12 sm:pb-12" : ""}
             ${expanded ? "" : "max-h-[200px]"}
           `}


### PR DESCRIPTION
When the browser width is insufficient, the sample code will not display fully