### PR TITLE
Remove redundant overflow (Solves Issue #81)

### DIFF
--- a/docs/components/CodeAndExample.tsx
+++ b/docs/components/CodeAndExample.tsx
@@ -55,8 +55,9 @@ function CodeAndExample({
             p-3 sm:p-6
             md:rounded-b-lg
             refractor-highlight
+            overflow-auto
             ${collapsible ? "pb-12 sm:pb-12" : ""}
-            ${expanded ? "overflow-auto" : "max-h-[200px] overflow-clip"}
+            ${expanded ? "" : "max-h-[200px]"}
           `}
         >
           <pre className={`transition ${expanded ? "" : "opacity-40"}`}>

--- a/docs/components/CodeAndExample.tsx
+++ b/docs/components/CodeAndExample.tsx
@@ -55,9 +55,8 @@ function CodeAndExample({
             p-3 sm:p-6
             md:rounded-b-lg
             refractor-highlight
-            overflow-auto
             ${collapsible ? "pb-12 sm:pb-12" : ""}
-            ${expanded ? "" : "max-h-[200px]"}
+            ${expanded ? "overflow-auto" : "max-h-[200px] overflow-hidden"}
           `}
         >
           <pre className={`transition ${expanded ? "" : "opacity-40"}`}>


### PR DESCRIPTION
See issue #81 

Collapsable blocks of code in Safari were overflowing. 