### PR TITLE
tidying / performance updates to vec module

### DIFF
--- a/.api-report/mafs.api.md
+++ b/.api-report/mafs.api.md
@@ -390,7 +390,7 @@ export namespace vec {
     export function dot(v: Vector2, v2: Vector2): number;
     export function lerp(v1: Vector2, v2: Vector2, t: number): Vector2;
     export function mag(v: Vector2): number;
-    export type Matrix = [number, number, number, number, number, number, number, number, number];
+    export type Matrix = [number, number, number, number, number, number];
     export function matrixBuilder(m?: Matrix | null): {
         mult: (m: Matrix) => any;
         translate: (x: number, y: number) => any;
@@ -399,7 +399,7 @@ export namespace vec {
         shear: (x: number, y: number) => any;
         get: () => Matrix;
     };
-    export function matrixInvert(matrix: Matrix): Matrix | null;
+    export function matrixInvert(a: Matrix): Matrix | null;
     export function matrixMult(m: Matrix, m2: Matrix): Matrix;
     export function midpoint(v: Vector2, v2: Vector2): Vector2;
     export function normal(v: Vector2): Vector2;

--- a/docs/components/guide-examples/MovableEllipse.tsx
+++ b/docs/components/guide-examples/MovableEllipse.tsx
@@ -17,7 +17,7 @@ export default function MovableEllipse() {
     color: Theme.blue,
     // Constrain this point to only move in a circle
     constrain: (position) =>
-      vec.scale(vec.normalize(position), hintRadius),
+      vec.withMag(position, hintRadius),
   })
   const angle = Math.atan2(rotate.point[1], rotate.point[0])
 

--- a/src/vec.ts
+++ b/src/vec.ts
@@ -53,7 +53,7 @@ export namespace vec {
   export function lerp(v1: Vector2, v2: Vector2, t: number): Vector2 {
     const d = sub(v2, v1)
     const m = mag(d)
-    return add(v1, scale(normalize(d), t * m))
+    return add(v1, withMag(d, t*m));
   }
 
   /**
@@ -61,7 +61,7 @@ export namespace vec {
    */
   export function normalize(v: Vector2): Vector2 {
     const magnitude = mag(v)
-    return [v[0] / magnitude, v[1] / magnitude]
+    return scale(v, 1 / magnitude);
   }
 
   export function withMag(v: Vector2, m: number): Vector2 {
@@ -103,7 +103,9 @@ export namespace vec {
    * Rotates a vector around the origin. Shorthand for a rotation matrix
    */
   export function rotate(v: Vector2, a: number): Vector2 {
-    return [v[0] * Math.cos(a) - v[1] * Math.sin(a), v[0] * Math.sin(a) + v[1] * Math.cos(a)]
+    const c = Math.cos(a);
+    const s = Math.sin(a);
+    return [v[0] * c - v[1] * s, v[0] * s + v[1] * c]
   }
 
   /**
@@ -111,10 +113,7 @@ export namespace vec {
    */
   export function rotateAbout(v: Vector2, cp: Vector2, a: number): Vector2 {
     const v2 = sub(v, cp)
-    return add(cp, [
-      v2[0] * Math.cos(a) - v2[1] * Math.sin(a),
-      v2[0] * Math.sin(a) + v2[1] * Math.cos(a),
-    ])
+    return add(cp, rotate(v2, a));
   }
 
   /**

--- a/src/vec.ts
+++ b/src/vec.ts
@@ -56,16 +56,15 @@ export namespace vec {
     return add(v1, withMag(d, t*m));
   }
 
+  export function withMag(v: Vector2, m: number): Vector2 {
+    const magnitude = mag(v)
+    return scale(v, m / magnitude);
+  }
   /**
    * Return a normalized version of a vector
    */
   export function normalize(v: Vector2): Vector2 {
-    const magnitude = mag(v)
-    return scale(v, 1 / magnitude);
-  }
-
-  export function withMag(v: Vector2, m: number): Vector2 {
-    return scale(normalize(v), m)
+    return withMag(v, 1);
   }
 
   /**

--- a/src/vec.ts
+++ b/src/vec.ts
@@ -15,9 +15,10 @@ export namespace vec {
   export type Vector2 = [x: number, y: number]
 
   /**
-   * A 3x3 matrix (generally used for 2D transformations)
+   * A 2x3 representation of a 3x3 matrix used to transform and translate a
+   * two-dimensional vector.
    */
-  export type Matrix = [number, number, number, number, number, number, number, number, number]
+  export type Matrix = [number, number, number, number, number, number]
 
   /**
    * Add two vectors
@@ -53,18 +54,18 @@ export namespace vec {
   export function lerp(v1: Vector2, v2: Vector2, t: number): Vector2 {
     const d = sub(v2, v1)
     const m = mag(d)
-    return add(v1, withMag(d, t*m));
+    return add(v1, withMag(d, t * m))
   }
 
   export function withMag(v: Vector2, m: number): Vector2 {
     const magnitude = mag(v)
-    return scale(v, m / magnitude);
+    return scale(v, m / magnitude)
   }
   /**
    * Return a normalized version of a vector
    */
   export function normalize(v: Vector2): Vector2 {
-    return withMag(v, 1);
+    return withMag(v, 1)
   }
 
   /**
@@ -85,25 +86,22 @@ export namespace vec {
    * Multiply two matrices (compose 2D transformations)
    */
   export function matrixMult(m: Matrix, m2: Matrix): Matrix {
-    return [
-      m[0] * m2[0] + m[1] * m2[3] + m[2] * m2[6],
-      m[0] * m2[1] + m[1] * m2[4] + m[2] * m2[7],
-      m[0] * m2[2] + m[1] * m2[5] + m[2] * m2[8],
-      m[3] * m2[0] + m[4] * m2[3] + m[5] * m2[6],
-      m[3] * m2[1] + m[4] * m2[4] + m[5] * m2[7],
-      m[3] * m2[2] + m[4] * m2[5] + m[5] * m2[8],
-      m[6] * m2[0] + m[7] * m2[3] + m[8] * m2[6],
-      m[6] * m2[1] + m[7] * m2[4] + m[8] * m2[7],
-      m[6] * m2[2] + m[7] * m2[5] + m[8] * m2[8],
-    ]
+    return matrixCreate(
+      m[0] * m2[0] + m[1] * m2[3],
+      m[3] * m2[0] + m[4] * m2[3],
+      m[0] * m2[1] + m[1] * m2[4],
+      m[3] * m2[1] + m[4] * m2[4],
+      m[0] * m2[2] + m[1] * m2[5] + m[2],
+      m[3] * m2[2] + m[4] * m2[5] + m[5]
+    )
   }
 
   /**
    * Rotates a vector around the origin. Shorthand for a rotation matrix
    */
   export function rotate(v: Vector2, a: number): Vector2 {
-    const c = Math.cos(a);
-    const s = Math.sin(a);
+    const c = Math.cos(a)
+    const s = Math.sin(a)
     return [v[0] * c - v[1] * s, v[0] * s + v[1] * c]
   }
 
@@ -112,7 +110,7 @@ export namespace vec {
    */
   export function rotateAbout(v: Vector2, cp: Vector2, a: number): Vector2 {
     const v2 = sub(v, cp)
-    return add(cp, rotate(v2, a));
+    return add(cp, rotate(v2, a))
   }
 
   /**
@@ -151,12 +149,15 @@ export namespace vec {
   }
 
   /**
-   * Inverts a 3x3 matrix, returning null if the determinant is zero (indicating a degenerate
-   * transformation)
+   * Inverts a 3x3 matrix, returning null if the determinant is zero
+   * (indicating a degenerate transformation)
    */
-  export function matrixInvert(matrix: Matrix): Matrix | null {
-    const a = matrix
-    const out: Matrix = new Array(9) as Matrix
+  export function matrixInvert(a: Matrix): Matrix | null {
+    // Calculate the determinant
+    const mDet = det(a)
+    if (!mDet) return null
+
+    const invDet = 1.0 / mDet
 
     const a00 = a[0],
       a01 = a[1],
@@ -164,31 +165,15 @@ export namespace vec {
     const a10 = a[3],
       a11 = a[4],
       a12 = a[5]
-    const a20 = a[6],
-      a21 = a[7],
-      a22 = a[8]
 
-    const b01 = a22 * a11 - a12 * a21
-    const b11 = -a22 * a10 + a12 * a20
-    const b21 = a21 * a10 - a11 * a20
-
-    // Calculate the determinant
-    let det = a00 * b01 + a01 * b11 + a02 * b21
-
-    if (!det) return null
-    det = 1.0 / det
-
-    out[0] = b01 * det
-    out[1] = (-a22 * a01 + a02 * a21) * det
-    out[2] = (a12 * a01 - a02 * a11) * det
-    out[3] = b11 * det
-    out[4] = (a22 * a00 - a02 * a20) * det
-    out[5] = (-a12 * a00 + a02 * a10) * det
-    out[6] = b21 * det
-    out[7] = (-a21 * a00 + a01 * a20) * det
-    out[8] = (a11 * a00 - a01 * a10) * det
-
-    return out
+    return matrixCreate(
+      invDet * a11,
+      invDet * -a10,
+      invDet * -a01,
+      invDet * a00,
+      invDet * (a12 * a01 - a02 * a11),
+      invDet * (-a12 * a00 + a02 * a10)
+    )
   }
 
   /**
@@ -207,13 +192,14 @@ export namespace vec {
     return {
       mult: (m: Matrix) => matrixBuilder(matrixMult(m, _m)),
       translate: (x: number, y: number) =>
-        matrixBuilder(matrixMult([1, 0, x, 0, 1, y, 0, 0, 1], _m)),
-      rotate: (a: number) =>
-        matrixBuilder(
-          matrixMult([Math.cos(a), -Math.sin(a), 0, Math.sin(a), Math.cos(a), 0, 0, 0, 1], _m)
-        ),
-      scale: (x: number, y: number) => matrixBuilder(matrixMult([x, 0, 0, 0, y, 0, 0, 0, 1], _m)),
-      shear: (x: number, y: number) => matrixBuilder(matrixMult([1, x, 0, y, 1, 0, 0, 0, 1], _m)),
+        matrixBuilder(matrixMult(matrixCreate(1, 0, 0, 1, x, y), _m)),
+      rotate: (a: number) => {
+        const c = Math.cos(a)
+        const s = Math.sin(a)
+        return matrixBuilder(matrixMult(matrixCreate(c, s, -s, c), _m))
+      },
+      scale: (x: number, y: number) => matrixBuilder(matrixMult(matrixCreate(x, 0, 0, y), _m)),
+      shear: (x: number, y: number) => matrixBuilder(matrixMult(matrixCreate(1, y, x, 1), _m)),
       get: (): Matrix => [..._m],
     }
   }
@@ -233,5 +219,5 @@ export namespace vec {
  * Create a matrix
  */
 function matrixCreate(a = 1, b = 0, c = 0, d = 1, tx = 0, ty = 0): vec.Matrix {
-  return [a, c, tx, b, d, ty, 0, 0, 1]
+  return [a, c, tx, b, d, ty]
 }


### PR DESCRIPTION
This PR modifies the internal 3x3 transform-and-translate matrix to a 2x3, removing the redundant final row. I then pushed these changes through the matrix inversion and multiplication code, for what should be a nice performance improvement.

I also made a few small changes to the vector code that should save some computation and, hopefully, make the code more understandable to new folks coming in.