### PR TITLE
Better handling of canvas width

### DIFF
--- a/src/view/Mafs.tsx
+++ b/src/view/Mafs.tsx
@@ -70,7 +70,10 @@ export function Mafs({
   const desiredCssWidth = propWidth === "auto" ? "100%" : `${propWidth}px`
 
   const rootRef = React.useRef<HTMLDivElement>(null)
-  const { width = ssr ? 500 : 1 } = useResizeObserver<HTMLDivElement>({ ref: rootRef })
+  const { width = propWidth === "auto" ? (ssr ? 500 : 1) : propWidth } =
+    useResizeObserver<HTMLDivElement>({
+      ref: propWidth === "auto" ? rootRef : null,
+    })
 
   React.useEffect(() => {
     setVisible(true)

--- a/src/view/Mafs.tsx
+++ b/src/view/Mafs.tsx
@@ -44,10 +44,9 @@ export type MafsProps = React.PropsWithChildren<{
   onClick?: (point: vec.Vector2, event: MouseEvent) => void
 
   /**
-   * Enable rendering on the server side. If false, an empty view will still be rendered, with
-   * nothing in it.
-   *
-   * Note that server-side rendering complicated graphs can really bloat your HTML.
+   * @deprecated this was previously used to avoid rendering Mafs on the server
+   * side. However, Mafs now avoids rendering at all until it is mounted, so
+   * this prop is now ignored.
    */
   ssr?: boolean
 }>
@@ -119,16 +118,8 @@ function MafsCanvas({
   viewBox,
   preserveAspectRatio,
   children,
-  ssr,
   onClick,
 }: MafsCanvasProps) {
-  // TODO: Since MafsCanvas is only rendered once width > 0, this probably isn't needed anymore?
-  const [visible, setVisible] = React.useState(ssr ? true : false)
-
-  React.useEffect(() => {
-    setVisible(true)
-  }, [])
-
   let minZoom = 1
   let maxZoom = 1
   if (typeof zoom === "object") {
@@ -326,7 +317,7 @@ function MafsCanvas({
                 } as React.CSSProperties),
               }}
             >
-              {visible && children}
+              {children}
             </svg>
           </PaneManager>
         </TransformContext.Provider>


### PR DESCRIPTION
This PR implements both suggested solutions from #113:
- The "canvas" is only rendered once we have an actual width. To achieve this I've lifted part of the `<Mafs>` component into an internal `<MafsCanvas>` component. Now all the hooks and render logic in `<MafsCanvas>` can safely assume the width is non-zero.
- If the user passes an explicit pixel value (i.e. not "auto") to the `width` prop, that value will be used directly and the `useResizeObserver` is disabled. To disable the resize observer, I used the method suggested here: https://github.com/ZeeCoder/use-resize-observer#opting-out-of-or-delaying-resizeobserver-instantiation.

The code requires some cleaning up still:
- [ ] Passing each prop from `<Mafs>` to `<MafsCanvas>` individually is annoying, but I think it is necessary in order for the docgen to pick up the default values. But maybe there is a better way?
- [ ] There is a `visible` state that is enabled after the component is mounted, triggering a re-render to actually show the contents. I think this might not be necessary anymore, since we now always ensure the canvas has a size?

Fixes #113