### PR TITLE
Adds `disable` property to `MovablePoint` and implements dot grid coordinate system `Coordinates.Dot`

### DIFF
--- a/docs/app/guides/display/coordinates/page.tsx
+++ b/docs/app/guides/display/coordinates/page.tsx
@@ -1,18 +1,21 @@
 "use client"
 
-import { Coordinates } from "mafs"
-import { PropTable } from "components/PropTable"
 import CodeAndExample from "components/CodeAndExample"
+import { PropTable } from "components/PropTable"
+import { Coordinates } from "mafs"
 
-import CartesianCoordinatesExample from "guide-examples/display/coordinates/CartesianCoordinatesExample"
 import CartesianCoordinatesExampleSource from "!raw-loader!guide-examples/display/coordinates/CartesianCoordinatesExample"
+import CartesianCoordinatesExample from "guide-examples/display/coordinates/CartesianCoordinatesExample"
 
-import CartesianCoordinatesConfigExample from "guide-examples/display/coordinates/CartesianCoordinatesConfigExample"
 import CartesianCoordinatesConfigExampleSource from "!raw-loader!guide-examples/display/coordinates/CartesianCoordinatesConfigExample"
 import Code from "components/Code"
+import CartesianCoordinatesConfigExample from "guide-examples/display/coordinates/CartesianCoordinatesConfigExample"
 
-import PolarCoordinatesExample from "guide-examples/display/coordinates/PolarCoordinatesExample"
 import PolarCoordinatesExampleSource from "!raw-loader!guide-examples/display/coordinates/PolarCoordinatesExample"
+import PolarCoordinatesExample from "guide-examples/display/coordinates/PolarCoordinatesExample"
+
+import DotCoordinatesExampleSource from "!raw-loader!guide-examples/display/coordinates/DotCoordinatesExample"
+import DotCoordinatesExample from "guide-examples/display/coordinates/DotCoordinatesExample"
 
 function CoordinatesPage() {
   return (
@@ -88,6 +91,13 @@ function CoordinatesPage() {
         <code>lines</code> and <code>subdivisions</code> affects the radial rather than the{" "}
         <code>x</code> and <code>y</code> axes.
       </p>
+
+      <h2>Dot coordinates</h2>
+
+      <CodeAndExample
+        component={<DotCoordinatesExample />}
+        source={DotCoordinatesExampleSource}
+      />
     </>
   )
 }

--- a/docs/components/guide-examples/display/coordinates/DotCoordinatesExample.tsx
+++ b/docs/components/guide-examples/display/coordinates/DotCoordinatesExample.tsx
@@ -1,0 +1,9 @@
+import { Coordinates, Mafs } from "mafs"
+
+export default function Example() {
+    return (
+        <Mafs height={300}>
+            <Coordinates.Dot subdivisions={4} xAxis={false} yAxis={false} />
+        </Mafs>
+    )
+}

--- a/src/display/Coordinates/Dot.tsx
+++ b/src/display/Coordinates/Dot.tsx
@@ -1,0 +1,114 @@
+import { usePaneContext } from "../../context/PaneContext"
+import { useTransformContext } from "../../context/TransformContext"
+import { range, round } from "../../math"
+import { vec } from "../../vec"
+import { AxisOptions, XLabels, YLabels, defaultAxisOptions } from "./Axes"
+
+// This is sort of a hack—every SVG pattern on a page needs a unique ID, otherwise they conflict.
+let incrementer = 0
+
+type GridAxisOptions = Partial<AxisOptions & { subdivisions: number | false }>
+
+export interface DotCoordinatesProps {
+    xAxis?: GridAxisOptions | false
+    yAxis?: GridAxisOptions | false
+    subdivisions?: number | false
+}
+
+export function Dot({
+    xAxis: xAxisOverrides,
+    yAxis: yAxisOverrides,
+    subdivisions = false,
+}: DotCoordinatesProps) {
+    const xAxisEnabled = xAxisOverrides !== false
+    const yAxisEnabled = yAxisOverrides !== false
+
+    const xAxis = { subdivisions, ...defaultAxisOptions, ...xAxisOverrides } as GridAxisOptions
+    const yAxis = { subdivisions, ...defaultAxisOptions, ...yAxisOverrides } as GridAxisOptions
+
+    const id = `cartesian-${incrementer++}`
+
+    const { viewTransform } = useTransformContext()
+    const { xPaneRange, yPaneRange } = usePaneContext()
+
+    const [xMin, xMax] = xPaneRange
+    const [yMin, yMax] = yPaneRange
+
+    const [vxMin, vyMin] = vec.transform([xMin, yMin], viewTransform)
+    const [vxMax, vyMax] = vec.transform([xMax, yMax], viewTransform)
+
+    const xLines = xAxis.lines || 1
+    const yLines = yAxis.lines || 1
+
+    const [unitW, unitH] = vec.transform([xLines, -yLines], viewTransform)
+
+    const xSubs = xAxis.subdivisions || 1
+    const ySubs = yAxis.subdivisions || 1
+
+    const subUnitW = unitW / xSubs
+    const subUnitH = unitH / ySubs
+
+    const dotRadius = 1.5
+    const subDotRadius = 0.7
+
+    return (
+        <g fill="none">
+            <pattern x={0} y={0} width={unitW} height={unitH} id={id} patternUnits="userSpaceOnUse">
+                <pattern
+                    width={subUnitW}
+                    height={subUnitH}
+                    id={`${id}-subdivision`}
+                    patternUnits="userSpaceOnUse"
+                >
+                    <g stroke="var(--grid-line-subdivision-color)" fill="var(--grid-line-subdivision-color)">
+                        <circle cx={0} cy={0} r={subDotRadius} />
+                        <circle cx={subUnitW} cy={0} r={subDotRadius} />
+                        <circle cx={0} cy={subUnitH} r={subDotRadius} />
+                        <circle cx={subUnitW} cy={subUnitH} r={subDotRadius} />
+                    </g>
+                </pattern>
+
+
+                <rect width={unitW} height={unitH} fill={`url(#${id}-subdivision)`} />
+
+                <g stroke="var(--mafs-line-color)" fill="var(--mafs-line-color)">
+                    <circle cx={0} cy={0} r={dotRadius} />
+                    <circle cx={unitW} cy={0} r={dotRadius} />
+                    <circle cx={0} cy={unitH} r={dotRadius} />
+                    <circle cx={unitW} cy={unitH} r={dotRadius} />
+                </g>
+            </pattern>
+
+            <rect x={vxMin} y={vyMax} width={vxMax - vxMin} height={vyMin - vyMax} fill={`url(#${id})`} />
+
+            <g stroke="var(--mafs-origin-color)">
+                {xAxisEnabled && xAxis.axis && <line x1={vxMin} y1={0} x2={vxMax} y2={0} />}
+                {yAxisEnabled && yAxis.axis && <line x1={0} y1={vyMin} x2={0} y2={vyMax} />}
+            </g>
+
+            <g className="mafs-shadow">
+                {xAxisEnabled && xAxis.labels && (
+                    <XLabels separation={xAxis.lines || 1} labelMaker={xAxis.labels} />
+                )}
+                {yAxisEnabled && yAxis.labels && (
+                    <YLabels separation={yAxis.lines || 1} labelMaker={yAxis.labels} />
+                )}
+            </g>
+        </g>
+    )
+}
+
+export function snappedRange(min: number, max: number, step: number) {
+    const roundMin = Math.floor(min / step) * step
+    const roundMax = Math.ceil(max / step) * step
+
+    if (roundMin === roundMax - step) return [roundMin]
+    return range(roundMin, roundMax - step, step)
+}
+
+export function autoPi(x: number): string {
+    if (x === 0) return "0"
+    if (Math.abs(Math.PI - x) < 0.001) return "π"
+    if (Math.abs(-Math.PI - x) < 0.001) return "-π"
+    return `${round(x / Math.PI, 5)}π`
+}

--- a/src/display/Coordinates/index.tsx
+++ b/src/display/Coordinates/index.tsx
@@ -1,12 +1,17 @@
 import { Cartesian } from "./Cartesian"
+import { Dot } from "./Dot"
 import { PolarCoordinates as Polar } from "./Polar"
 
 // @ts-expect-error - setting these here to avoid invalid .d.ts output
 Polar.displayName = "Coordinates.Polar"
 // @ts-expect-error - setting these here to avoid invalid .d.ts output
 Cartesian.displayName = "Coordinates.Cartesian"
+// @ts-expect-error - setting these here to avoid invalid .d.ts output
+Dot.displayName = "Coordinates.Dot"
+
 
 export const Coordinates = {
-  Cartesian,
-  Polar,
+    Cartesian,
+    Polar,
+    Dot,
 }

--- a/src/interaction/useMovablePoint.tsx
+++ b/src/interaction/useMovablePoint.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+import { Point } from "../display/Point"
 import { Theme } from "../display/Theme"
 import { vec } from "../vec"
 import { MovablePoint } from "./MovablePoint"
@@ -7,6 +8,7 @@ export type ConstraintFunction = (position: vec.Vector2) => vec.Vector2
 
 export interface UseMovablePointArguments {
   color?: string
+  disable?: boolean
 
   /**
    * Constrain the point to only horizontal movement, vertical movement, or mapped movement.
@@ -27,7 +29,7 @@ export interface UseMovablePoint {
 
 export function useMovablePoint(
   initialPoint: vec.Vector2,
-  { constrain, color = Theme.pink }: UseMovablePointArguments = {},
+  { constrain, disable = false, color = Theme.pink }: UseMovablePointArguments = {},
 ): UseMovablePoint {
   const [initialX, initialY] = initialPoint
   const [point, setPoint] = React.useState<vec.Vector2>(initialPoint)
@@ -46,7 +48,8 @@ export function useMovablePoint(
   }, [constrain, initialX, initialY])
 
   const element = React.useMemo(() => {
-    return <MovablePoint {...{ point, color }} constrain={constraintFunction} onMove={setPoint} />
+    if (disable) return <Point {...{ point, color }} x={x} y={y} />
+    else return <MovablePoint {...{ point, color }} constrain={constraintFunction} onMove={setPoint} />
   }, [point, color, constraintFunction])
 
   return {

--- a/src/interaction/useMovablePoint.tsx
+++ b/src/interaction/useMovablePoint.tsx
@@ -50,7 +50,7 @@ export function useMovablePoint(
   const element = React.useMemo(() => {
     if (disable) return <Point {...{ point, color }} x={x} y={y} />
     else return <MovablePoint {...{ point, color }} constrain={constraintFunction} onMove={setPoint} />
-  }, [point, color, constraintFunction])
+  }, [point, color, constraintFunction, disable])
 
   return {
     x,


### PR DESCRIPTION
Hello.
I would find it useful if there was some kind of short-hand syntax for enabling/disabling MovablePoint's.
An example scenario would be an wysiwyg-editor where you can create and mutate `mafs` elements.

Second I thought of a dot grid coordinate system which could provide people with another option by being more minimalistic/focussed/simplified compared to the default Cartesian design.

I am interested in whether it is a suitable extension for the library.

PS: I have got a whole bunch of ideas how to extend the library due to the current project I am working on.

<img width="821" alt="Screenshot 2024-02-18 at 21 15 06" src="https://github.com/stevenpetryk/mafs/assets/74831031/a5cee274-e0e5-45cb-8216-0287690e6974">
