### PR TITLE
Fix `pnpm start` by updating docgen import

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
 import ts from "typescript"
-import docgen from "react-docgen-typescript"
+import * as docgen from "react-docgen-typescript"
 
 import { writeDocgenResults } from "./docgen"
 


### PR DESCRIPTION
I'm worried this might just be my own ignorance about `pnpm`, but here's what was happening:

- `pnpm install`
- `pnpm start` (both from the [README](https://github.com/stevenpetryk/mafs?tab=readme-ov-file#development))
- Error:

```
(khan27) MatthewrtissMBP:mafs matthewcurtis$ pnpm start

> mafs@0.18.4 start /Users/PATH/mafs
> tsx scripts/dev.ts

Docgen updated /Users/PATH/mafs/docs/generated-docgen.tsx
/Users/PATH/mafs/scripts/dev.ts:16
const customDocgen = docgen.withCustomConfig(tsconfig, { shouldRemoveUndefinedFromOptional: true })
                            ^
TypeError: Cannot read properties of undefined (reading 'withCustomConfig')
    at ts (/Users/PATH/mafs/scripts/dev.ts:16:29)
    at Object.<anonymous> (/Users/PATH/mafs/scripts/dev.ts:67:6)
    at Module._compile (node:internal/modules/cjs/loader:1376:14)
    at Object.S (/Users/PATH/mafs/node_modules/.pnpm/tsx@4.7.1/node_modules/tsx/dist/cjs/index.cjs:1:1292)
    at Module.load (node:internal/modules/cjs/loader:1207:32)
    at Module._load (node:internal/modules/cjs/loader:1023:12)
    at cjsLoader (node:internal/modules/esm/translators:356:17)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:305:7)
    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)
    at async ModuleLoader.import (node:internal/modules/esm/loader:329:24)

Node.js v20.11.1
 ELIFECYCLE  Command failed with exit code 1.
```

I traced it to `dev.ts` specifically:

``` TS
import docgen from "react-docgen-typescript"
// ...etc...
const customDocgen = docgen.withCustomConfig(tsconfig, { shouldRemoveUndefinedFromOptional: true })
```

In `docgen.ts` it was:

``` TS
import * as docgen from "react-docgen-typescript"
// ...etc...
const parse = docgen.withCustomConfig(tsConfigPath, {
  shouldRemoveUndefinedFromOptional: true,
}).parseWithProgramProvider
```

So I made the change and the docs are building now 🤷