### PR TITLE
Fix "Edit in StackBlitz" feature on documentation site

### DIFF
--- a/docs/components/CodeAndExample.tsx
+++ b/docs/components/CodeAndExample.tsx
@@ -114,6 +114,8 @@ async function openPlayground(source: string) {
   const prettier = await import("prettier/standalone")
   const typescriptParser = await import("prettier/plugins/typescript")
   const htmlParser = await import("prettier/plugins/html")
+  // https://github.com/prettier/prettier/issues/15473
+  const prettierPluginEstree = await import("prettier/plugins/estree")
 
   const tsx = await prettier.format(
     endent`
@@ -127,7 +129,7 @@ async function openPlayground(source: string) {
 
         createRoot(document.getElementById("root")).render(<${functionName} />)
       `,
-    { parser: "typescript", plugins: [typescriptParser] },
+    { parser: "typescript", plugins: [typescriptParser, prettierPluginEstree as {}] },
   )
 
   const html = await prettier.format(

--- a/docs/components/CodeAndExample.tsx
+++ b/docs/components/CodeAndExample.tsx
@@ -114,7 +114,7 @@ async function openPlayground(source: string) {
   const prettier = await import("prettier/standalone")
   const typescriptParser = await import("prettier/plugins/typescript")
   const htmlParser = await import("prettier/plugins/html")
-  // https://github.com/prettier/prettier/issues/15473
+  // @ts-expect-error - https://github.com/prettier/prettier/issues/15473
   const prettierPluginEstree = await import("prettier/plugins/estree")
 
   const tsx = await prettier.format(

--- a/docs/components/CodeAndExample.tsx
+++ b/docs/components/CodeAndExample.tsx
@@ -114,8 +114,7 @@ async function openPlayground(source: string) {
   const prettier = await import("prettier/standalone")
   const typescriptParser = await import("prettier/plugins/typescript")
   const htmlParser = await import("prettier/plugins/html")
-  // @ts-expect-error - https://github.com/prettier/prettier/issues/15473
-  const prettierPluginEstree = await import("prettier/plugins/estree")
+  const { default: prettierPluginEstree } = await import("prettier/plugins/estree")
 
   const tsx = await prettier.format(
     endent`

--- a/docs/components/CodeAndExample.tsx
+++ b/docs/components/CodeAndExample.tsx
@@ -129,7 +129,7 @@ async function openPlayground(source: string) {
 
         createRoot(document.getElementById("root")).render(<${functionName} />)
       `,
-    { parser: "typescript", plugins: [typescriptParser, prettierPluginEstree as {}] },
+    { parser: "typescript", plugins: [typescriptParser, prettierPluginEstree] },
   )
 
   const html = await prettier.format(

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "fs-extra": "^11.1.1",
     "jest": "^29.6.2",
     "jest-image-snapshot": "^6.2.0",
-    "prettier": "^3",
+    "prettier": "^3.2.5",
     "react": "^18.2.0",
     "react-docgen-typescript": "2.2.2",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0(jest@29.6.2)
       prettier:
-        specifier: ^3
-        version: 3.0.0
+        specifier: ^3.2.5
+        version: 3.2.5
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -5812,8 +5812,8 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /prettier@3.0.0:
-    resolution: {integrity: sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==}
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
 import ts from "typescript"
-import docgen from "react-docgen-typescript"
+import * as docgen from "react-docgen-typescript"
 
 import { writeDocgenResults } from "./docgen"
 


### PR DESCRIPTION
This pull request addresses an issue where users were unable to use the **`Edit in StackBlitz`** feature due to an error thrown by the `prettier.format` API. 

The following changes have been implemented:

- imported the `estree` plugin as a solution to the aforementioned error, following the discussion in prettier/prettier#15473
- updated the `prettier` version due to the types issue detailed in prettier/prettier#15136
- also fix the development script's launch error, keep it same with `docgen.ts`

<img width="1112" alt="image" src="https://github.com/stevenpetryk/mafs/assets/15135943/6fd6368a-14b1-4518-a810-6a944932afac">
