### PR TITLE
Make line stroke style overridable

### DIFF
--- a/core.css
+++ b/core.css
@@ -14,6 +14,7 @@
 
   --mafs-origin-color: var(--mafs-fg);
   --mafs-line-color: #555;
+  --mafs-line-stroke-dash-style: 4, 3;
   --grid-line-subdivision-color: #222;
 
   --mafs-red: #f11d0e;

--- a/src/display/Ellipse.tsx
+++ b/src/display/Ellipse.tsx
@@ -44,11 +44,12 @@ export function Ellipse({
       rx={radius[0]}
       ry={radius[1]}
       strokeWidth={weight}
-      strokeDasharray={strokeStyle === "dashed" ? "4,3" : undefined}
       transform={cssTransform}
       {...svgEllipseProps}
       style={{
         stroke: color,
+        strokeDasharray:
+          strokeStyle === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined,
         fill: color,
         fillOpacity,
         strokeOpacity,

--- a/src/display/Line/Segment.tsx
+++ b/src/display/Line/Segment.tsx
@@ -28,10 +28,12 @@ export function Segment({
       y1={round(scaledPoint1[1], 2)}
       x2={round(scaledPoint2[0], 2)}
       y2={round(scaledPoint2[1], 2)}
-      style={{ stroke: color }}
+      style={{
+        stroke: color,
+        strokeDasharray: style === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined,
+      }}
       strokeWidth={weight}
       opacity={opacity}
-      strokeDasharray={style === "dashed" ? "1,10" : undefined}
     />
   )
 }

--- a/src/display/Line/ThroughPoints.tsx
+++ b/src/display/Line/ThroughPoints.tsx
@@ -47,12 +47,12 @@ export function ThroughPoints({
       y2={round(offscreen2[1], 2)}
       style={{
         stroke: color,
+        strokeDasharray: style === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined,
         transform: "var(--mafs-view-transform)",
         vectorEffect: "non-scaling-stroke",
       }}
       strokeWidth={weight}
       opacity={opacity}
-      strokeDasharray={style === "dashed" ? "4,3" : undefined}
     />
   )
 }

--- a/src/display/Plot/Parametric.tsx
+++ b/src/display/Plot/Parametric.tsx
@@ -48,11 +48,11 @@ export function Parametric({
       fill="none"
       strokeLinecap="round"
       strokeLinejoin="round"
-      strokeDasharray={style === "dashed" ? "1,10" : undefined}
       {...svgPathProps}
       style={{
         stroke: color || "var(--mafs-fg)",
         strokeOpacity: opacity,
+        strokeDasharray: style === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined,
         vectorEffect: "non-scaling-stroke",
         transform: "var(--mafs-view-transform)",
         ...(svgPathProps.style || {}),

--- a/src/display/PolyBase.tsx
+++ b/src/display/PolyBase.tsx
@@ -37,13 +37,14 @@ export function PolyBase({
       points={scaledPoints}
       strokeWidth={weight}
       fillOpacity={fillOpacity}
-      strokeDasharray={strokeStyle === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined}
       strokeLinejoin="round"
       {...svgPolyProps}
       style={{
         fill: color,
         fillOpacity,
         stroke: color,
+        strokeDasharray:
+          strokeStyle === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined,
         strokeOpacity,
         vectorEffect: "non-scaling-stroke",
         transform: "var(--mafs-view-transform)",

--- a/src/display/PolyBase.tsx
+++ b/src/display/PolyBase.tsx
@@ -37,7 +37,7 @@ export function PolyBase({
       points={scaledPoints}
       strokeWidth={weight}
       fillOpacity={fillOpacity}
-      strokeDasharray={strokeStyle === "dashed" ? "4,3" : undefined}
+      strokeDasharray={strokeStyle === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined}
       strokeLinejoin="round"
       {...svgPolyProps}
       style={{

--- a/src/display/Vector.tsx
+++ b/src/display/Vector.tsx
@@ -44,10 +44,10 @@ export function Vector({
         y2={pixelTip[1]}
         strokeWidth={weight}
         markerEnd={`url(#${id})`}
-        strokeDasharray={style === "dashed" ? "4,3" : undefined}
         {...svgLineProps}
         style={{
           stroke: color || "var(--mafs-fg)",
+          strokeDasharray: style === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined,
           fill: color,
           strokeOpacity: opacity,
           ...(svgLineProps?.style || {}),


### PR DESCRIPTION
## Summary:

We noticed that the dashed line style for Mafs lines varied some across the different lines it draws. The `stroke-dasharray` prop value was also hard-coded in the components and so couldn't be adjusted by a consuming application.

This PR adjusts all (except `Plot.Inequalities`) lines to use a CSS variable for the dash style.

| Type |  Screenshot |
| --- | --- |
| Segment | <img width="500" alt="image" src="https://github.com/stevenpetryk/mafs/assets/77138/f8dac8f9-31e3-4f11-ad20-97bf88dc7df5"> | 
| ThroughPoints | <img width="500" alt="image" src="https://github.com/stevenpetryk/mafs/assets/77138/6ed86d85-ca0d-46ae-840d-dbc7bf4fe55c"> |
| PointSlope | <img width="500" alt="image" src="https://github.com/stevenpetryk/mafs/assets/77138/8b24bed7-04c4-462d-98c5-71c8286b8a39"> | 
| PointAngle | <img width="500" alt="image" src="https://github.com/stevenpetryk/mafs/assets/77138/85044d10-1bbd-415d-bd10-f549a0940d64"> |
| Plot OfX and OfY |  <img width="500" alt="image" src="https://github.com/stevenpetryk/mafs/assets/77138/303a4c6c-00f9-4a67-a076-b12aee99fa29"> |
| Polyline |  <img width="500" alt="image" src="https://github.com/stevenpetryk/mafs/assets/77138/d1fb811f-fa3b-4148-94fa-f46c6d5c9749"> | 
| Circle |  <img width="500" alt="image" src="https://github.com/stevenpetryk/mafs/assets/77138/32d0c137-8fff-4e8e-98eb-2e5b3714cc9a"> |
| Ellipse | <img width="500" alt="image" src="https://github.com/stevenpetryk/mafs/assets/77138/73fdc4fa-3367-4a3f-92dd-0c15844dcfe5"> |
| Parametric |  <img width="500" alt="image" src="https://github.com/stevenpetryk/mafs/assets/77138/92949a69-f529-4cc8-980d-df0af1d00e7f"> | 


## Test plan:

Edit the line examples in `docs/components/guide-examples/LinePointSlopeExample.tsx` (for example) to use `style="dashed"` for the line.

`yarn start` 

Check the line dash style