### PR TITLE
Relax node version constraint to >= 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "types": "build/index.d.ts",
   "packageManager": "pnpm@9.0.6",
   "engines": {
-    "node": "^20.11"
+    "node": ">=20"
   },
   "files": [
     "build/",


### PR DESCRIPTION
Khan Academy uses various minor versions of Node 20 in different places (e.g. CI vs. dev). The current node version constraint of `^20.11` is causing errors when we install NPM packages using an earlier minor release of Node.

This commit changes the constraint to allow any node version >= 20.

I've confirmed that `pnpm test` passes on node 20.0.0. Is there anything else I should test to make sure this change is good?