### PR TITLE
Avoid rendering zero-length vectors in VectorField

### DIFF
--- a/src/display/Plot/VectorField.tsx
+++ b/src/display/Plot/VectorField.tsx
@@ -37,6 +37,10 @@ export function VectorField({
         const tail: vec.Vector2 = [x, y]
         const trueOffset = xy([x, y])
         const trueMag = vec.mag(trueOffset)
+
+        // Avoid rendering zero-length vectors
+        if (trueMag === 0) continue
+
         const scaledOffset = vec.scale(vec.normalize(trueOffset), Math.min(trueMag, step * 0.75))
         const tip = vec.add(tail, scaledOffset)
 


### PR DESCRIPTION
Closes #164.

`vec.normalize([0,0])` returns `[NaN, NaN]` (which is perhaps not great? perhaps `vec.normalize`'s return value should be nullable or something).

Anyway, those NaNs were making their way into the SVG path, breaking it.
