### PR TITLE
Fix 'overhandling' of arrow keypresses

### DIFF
--- a/src/interaction/useMovable.tsx
+++ b/src/interaction/useMovable.tsx
@@ -38,6 +38,17 @@ export function useMovable(args: UseMovableArguments): UseMovable {
       const isKeyboard = type.includes("key")
       if (isKeyboard) {
         event?.preventDefault()
+
+        // When a key is held down, we see multiple "keydown" events,
+        // followed by a single "keyup" event.
+        // For a single keypress, we only see a "keydown" event, no
+        // "keyup".
+        // We never want to process the keyup event as an intent to
+        // move so we bail on further processing here.
+        if (type === "keyup") {
+          return
+        }
+
         const { direction: yDownDirection, altKey, metaKey, shiftKey } = state
 
         const direction = [yDownDirection[0], -yDownDirection[1]] as vec.Vector2


### PR DESCRIPTION
## Summary:

Over in github.com/Khan/perseus#1445 we noticed that our vendored (and slightly customized) version of `useMovable` (which we've renamed `useDraggable`) had a bug where we handled both `keydown` and `keyup` events, causing a sort of "double dispatch" of move events. 

This is because (from our observations in modern browsers), a single keypress only triggers a `keydown` (but no `keyup`). If you hold the key down, you get multiple `keydown` events and a single `keyup` when the key is released. 

This can be observed if you look closely on https://mafs.dev/guides/interaction/movable-points. 

If you select the point and then hold down an arrow key until it start moving, let go and you'll notice it seems to "overshoot" the stopping point. This is because the final `keyup` is processed as a distinct event, causing one extra move. This is subtle but the fix makes the feel of holding and releasing the arrow keys for movement feel more natural.

It also fixes an issue where movement keypresses on a mobile device (iPhone) using a connected bluetooth keyboard cause double-movement. 

## Test plan:

`yarn start`
Navigate to the "Movable Points" page
Select the movable point with the keyboard
Hold down an arrow key until the point moves multiple times
Release the arrow key
Note that the point stops as you'd expect
(Previously, the point would "overshoot" by one movement)