### PR TITLE
Add "auto" option to Coordinates.Cartesian

### DIFF
--- a/src/math.ts
+++ b/src/math.ts
@@ -6,6 +6,23 @@ export function round(value: number, precision = 0): number {
   return Math.round(value * multiplier) / multiplier
 }
 
+// TODO: Maybe better name (even though this one perfectly describes its purpose)
+export function roundToNearestPowerOf10(value: number): number {
+  return 10 ** Math.floor(Math.log10(value))
+}
+
+export function pickClosestToValue(value: number, options: number[]) {
+  // [Distance from value to option, index of option]
+  const distanceMap = options
+    .map((option, i) => [Math.abs(option - value), i])
+    .sort((a, b) => a[0] - b[0])
+
+	const closest = distanceMap[0];
+
+	// [value, index]
+  return [options[closest[1]], closest[1]];
+}
+
 export function range(min: number, max: number, step = 1): number[] {
   const result = []
   for (let i = min; i < max - step / 2; i += step) {

--- a/src/math.ts
+++ b/src/math.ts
@@ -17,10 +17,10 @@ export function pickClosestToValue(value: number, options: number[]) {
     .map((option, i) => [Math.abs(option - value), i])
     .sort((a, b) => a[0] - b[0])
 
-	const closest = distanceMap[0];
+  const closest = distanceMap[0]
 
-	// [value, index]
-  return [options[closest[1]], closest[1]];
+  // [value, index]
+  return [options[closest[1]], closest[1]]
 }
 
 export function range(min: number, max: number, step = 1): number[] {


### PR DESCRIPTION
Added experimental "auto" option for cartesian coordinates that will automatically change the amount of gridlines based on zoom level. No config options for it yet, it just enables it with some default settings if you pass `"auto"` into `xAxis` or `yAxis`.

https://github.com/user-attachments/assets/0c1dcbce-1eb2-4d44-baf4-cf50a0eff2ff

