### PR TITLE
Changed the title

### DIFF
--- a/docs/app/guides/custom-components/overview/page.tsx
+++ b/docs/app/guides/custom-components/overview/page.tsx
@@ -2,7 +2,7 @@ import PizzaMarch from "guide-examples/custom/pizza-march"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "Custom components",
+  title: "Overview",
 }
 
 export default function CustomPage() {


### PR DESCRIPTION
Due to the incorrect title, the navigation buttons duplicate the text.