### PR TITLE
Define Ellipse in terms of 2 foci

### DIFF
--- a/docs/app/guides/display/ellipses/page.tsx
+++ b/docs/app/guides/display/ellipses/page.tsx
@@ -1,7 +1,9 @@
 import CodeAndExample from "components/CodeAndExample"
 
-import MovableEllipse from "guide-examples/MovableEllipse"
-import WIP from "components/WIP"
+import MovableEllipseCenter from "guide-examples/MovableEllipse/Center"
+import MovableEllipseSemiMajorAxis from "guide-examples/MovableEllipse/SemiMajorAxis"
+import MovableEllipseSemiMinorAxis from "guide-examples/MovableEllipse/SemiMinorAxis"
+import MovableEllipseEccentricity from "guide-examples/MovableEllipse/Eccentricity"
 import Link from "next/link"
 
 import { PropTable } from "components/PropTable"
@@ -14,19 +16,29 @@ export const metadata: Metadata = {
 export default function Page() {
   return (
     <>
+      <p>There are a few components for ellipses, depending on how you want to construct them.</p>
+      <h2>Center, Radii and Angle</h2>
       <p>Ellipses take a center vector, radius vector, and an angle.</p>
 
-      <CodeAndExample example={MovableEllipse} />
+      <CodeAndExample example={MovableEllipseCenter} />
 
-      <PropTable of={"Ellipse"} />
+      <PropTable of={"Ellipse.Center"} />
 
-      <WIP>
-        <p>
-          Support for defining ellipses in terms of two foci is planned. In the meantime, you can
-          accomplish this using a{" "}
-          <Link href="/guides/display/function-graphs/">parametric function</Link>.
-        </p>
-      </WIP>
+      <h2>Ellipse with two foci</h2>
+      <p>There are a few ways to define an ellipse with two foci.</p>
+      <h3>Semi-Major Axis</h3>
+      <p>Ellipses take 2 foci and a Semi-Major Axis.</p>
+
+      <CodeAndExample example={MovableEllipseSemiMajorAxis}/>
+
+      <h3>Semi-Minor Axis</h3>
+      <p>Ellipses take 2 foci and a Semi-Minor Axis.</p>
+
+      <CodeAndExample example={MovableEllipseSemiMinorAxis}/>
+      <h3>Eccentricity</h3>
+      <p>Ellipses take 2 foci and an eccentricity between 0 and 1.</p>
+
+      <CodeAndExample example={MovableEllipseEccentricity}/>
     </>
   )
 }

--- a/docs/components/guide-examples/MovableEllipse/Center.tsx
+++ b/docs/components/guide-examples/MovableEllipse/Center.tsx
@@ -46,7 +46,7 @@ export default function MovableEllipse() {
             fillOpacity={0}
           />
 
-          <Ellipse
+          <Ellipse.Center
             center={[0, 0]}
             radius={[Math.abs(width.x), Math.abs(height.y)]}
           />

--- a/docs/components/guide-examples/MovableEllipse/Eccentricity.tsx
+++ b/docs/components/guide-examples/MovableEllipse/Eccentricity.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+// prettier-ignore
+import { Mafs, Ellipse, Coordinates, useMovablePoint, Theme, vec, Transform } from "mafs"
+import { useEffect } from 'react'
+import clamp from 'lodash/clamp'
+
+export default function MovableEllipse() {
+  const focus1 = useMovablePoint([-Math.sqrt(3),0], {
+    color: Theme.orange,
+  })
+  const focus2 = useMovablePoint([ Math.sqrt(3),0], {
+    color: Theme.orange,
+  })
+  const eccentricity = useMovablePoint([6,Math.sqrt(3)/2], {
+    constrain: (position) => [6,clamp(position[1],0,1)]
+  })
+
+  return (
+    <Mafs height={400} viewBox={{ x: [-3, 3], y: [-3, 3] }}>
+      <Coordinates.Cartesian/>
+      <Ellipse.Eccentricity
+        focus1={focus1.point}
+        focus2={focus2.point}
+        eccentricity={eccentricity.point[1]}
+      />
+      {focus1.element}
+      {focus2.element}
+      {eccentricity.element}
+    </Mafs>
+  )
+}
+

--- a/docs/components/guide-examples/MovableEllipse/SemiMajorAxis.tsx
+++ b/docs/components/guide-examples/MovableEllipse/SemiMajorAxis.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+// prettier-ignore
+import { Mafs, Ellipse, Coordinates, useMovablePoint, Theme, vec, Transform } from "mafs"
+import { useEffect } from 'react'
+
+export default function MovableEllipse() {
+  const focus1 = useMovablePoint([-Math.sqrt(3),0], {
+    color: Theme.orange,
+  })
+  const focus2 = useMovablePoint([ Math.sqrt(3),0], {
+    color: Theme.orange,
+  })
+  const semiMajorAxis = useMovablePoint([-2,0], {
+    constrain: (position) => {
+      const a1 = focus1.point
+      const a2 = focus2.point
+
+      const ab = vec.sub(a2, a1)
+      const ap = vec.sub(position, a1)
+
+      const len2 = vec.dot(ab, ab)
+      if (len2 == 0) return [...a1]
+
+      const t = vec.dot(ap, ab) / len2
+
+      return vec.add(a1, vec.scale(ab, t))
+    }
+  })
+  const sma = vec.dist(semiMajorAxis.point,vec.midpoint(focus1.point,focus2.point))
+
+  return (
+    <Mafs height={400} viewBox={{ x: [-3, 3], y: [-3, 3] }}>
+      <Coordinates.Cartesian/>
+      <Ellipse.SemiMajorAxis
+        focus1={focus1.point}
+        focus2={focus2.point}
+        semiMajorAxis={sma}
+      />
+      {focus1.element}
+      {focus2.element}
+      {semiMajorAxis.element}
+    </Mafs>
+  )
+}

--- a/docs/components/guide-examples/MovableEllipse/SemiMinorAxis.tsx
+++ b/docs/components/guide-examples/MovableEllipse/SemiMinorAxis.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+// prettier-ignore
+import { Mafs, Ellipse, Coordinates, useMovablePoint, Theme, vec, Transform } from "mafs"
+import { useEffect } from 'react'
+
+export default function MovableEllipse() {
+  const focus1 = useMovablePoint([-Math.sqrt(3),0], {
+    color: Theme.orange,
+  })
+  const focus2 = useMovablePoint([ Math.sqrt(3),0], {
+    color: Theme.orange,
+  })
+  const semiMinorAxis = useMovablePoint([0,1], {
+    constrain: (position) => {
+      const a = focus1.point
+      const b = focus2.point
+
+      const ab = vec.sub(b, a)
+
+      const mid = vec.midpoint(a,b)
+
+      const perp = vec.normal(ab)
+
+      const denom = vec.dot(perp, perp)
+      if (denom === 0) return [...mid]
+
+      const ap = vec.sub(position, mid)
+
+      const t = vec.dot(ap, perp) / denom
+
+      return vec.add(mid, vec.scale(perp, t))
+    }
+  })
+  const sma = vec.dist(semiMinorAxis.point,vec.midpoint(focus1.point,focus2.point))
+
+  return (
+    <Mafs height={400} viewBox={{ x: [-3, 3], y: [-3, 3] }}>
+      <Coordinates.Cartesian/>
+      <Ellipse.SemiMinorAxis
+        focus1={focus1.point}
+        focus2={focus2.point}
+        semiMinorAxis={sma}
+      />
+      {focus1.element}
+      {focus2.element}
+      {semiMinorAxis.element}
+    </Mafs>
+  )
+}
+

--- a/src/display/Circle.tsx
+++ b/src/display/Circle.tsx
@@ -10,7 +10,7 @@ export interface CircleProps extends Filled {
 }
 
 export function Circle({ radius, ...rest }: CircleProps) {
-  return <Ellipse radius={[radius, radius]} {...rest} />
+  return <Ellipse.Center radius={[radius, radius]} {...rest} />
 }
 
 Circle.displayName = "Circle"

--- a/src/display/Ellipse.tsx
+++ b/src/display/Ellipse.tsx
@@ -1,63 +1,17 @@
-import * as React from "react"
-import { Filled, Theme } from "./Theme"
-import { useTransformContext } from "../context/TransformContext"
-import { vec } from "../vec"
+import { Center } from "./Ellipse/Center"
+import { Eccentricity } from "./Ellipse/Eccentricity"
+import { SemiMajorAxis } from "./Ellipse/SemiMajorAxis"
+import { SemiMinorAxis } from "./Ellipse/SemiMinorAxis"
 
-export interface EllipseProps extends Filled {
-  center: vec.Vector2
-  radius: vec.Vector2
-  angle?: number
-  svgEllipseProps?: React.SVGProps<SVGEllipseElement>
+export const Ellipse = {
+  Center,
+  Eccentricity,
+  SemiMajorAxis,
+  SemiMinorAxis,
 }
 
-export function Ellipse({
-  center,
-  radius,
-  angle = 0,
-  strokeStyle = "solid",
-  strokeOpacity = 1.0,
-  weight = 2,
-  color = Theme.foreground,
-  fillOpacity = 0.15,
-  svgEllipseProps = {},
-}: EllipseProps) {
-  const { viewTransform: toPx, userTransform } = useTransformContext()
-
-  const transform = vec
-    .matrixBuilder()
-    .translate(...center)
-    .mult(userTransform)
-    .scale(1, -1)
-    .mult(toPx)
-    .scale(1, -1)
-    .get()
-
-  const cssTransform = `
-    ${vec.toCSS(transform)}
-    rotate(${angle * (180 / Math.PI)})
-  `
-
-  return (
-    <ellipse
-      cx={0}
-      cy={0}
-      rx={radius[0]}
-      ry={radius[1]}
-      strokeWidth={weight}
-      transform={cssTransform}
-      {...svgEllipseProps}
-      style={{
-        stroke: color,
-        strokeDasharray:
-          strokeStyle === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined,
-        fill: color,
-        fillOpacity,
-        strokeOpacity,
-        vectorEffect: "non-scaling-stroke",
-        ...(svgEllipseProps.style || {}),
-      }}
-    />
-  )
-}
-
-Ellipse.displayName = "Ellipse"
+import type { CenterProps } from "./Ellipse/Center"
+import type { EccentricityProps } from "./Ellipse/Eccentricity"
+import type { SemiMajorAxisProps } from "./Ellipse/SemiMajorAxis"
+import type { SemiMinorAxisProps } from "./Ellipse/SemiMinorAxis"
+export type { CenterProps, EccentricityProps, SemiMajorAxisProps, SemiMinorAxisProps }

--- a/src/display/Ellipse/Center.tsx
+++ b/src/display/Ellipse/Center.tsx
@@ -1,0 +1,63 @@
+import * as React from "react"
+import { Filled, Theme } from "../Theme"
+import { useTransformContext } from "../../context/TransformContext"
+import { vec } from "../../vec"
+
+export interface CenterProps extends Filled {
+  center: vec.Vector2
+  radius: vec.Vector2
+  angle?: number
+  svgEllipseProps?: React.SVGProps<SVGEllipseElement>
+}
+
+export function Center({
+  center,
+  radius,
+  angle = 0,
+  strokeStyle = "solid",
+  strokeOpacity = 1.0,
+  weight = 2,
+  color = Theme.foreground,
+  fillOpacity = 0.15,
+  svgEllipseProps = {},
+}: CenterProps) {
+  const { viewTransform: toPx, userTransform } = useTransformContext()
+
+  const transform = vec
+    .matrixBuilder()
+    .translate(...center)
+    .mult(userTransform)
+    .scale(1, -1)
+    .mult(toPx)
+    .scale(1, -1)
+    .get()
+
+  const cssTransform = `
+    ${vec.toCSS(transform)}
+    rotate(${angle * (180 / Math.PI)})
+  `
+
+  return (
+    <ellipse
+      cx={0}
+      cy={0}
+      rx={radius[0]}
+      ry={radius[1]}
+      strokeWidth={weight}
+      transform={cssTransform}
+      {...svgEllipseProps}
+      style={{
+        stroke: color,
+        strokeDasharray:
+          strokeStyle === "dashed" ? "var(--mafs-line-stroke-dash-style)" : undefined,
+        fill: color,
+        fillOpacity,
+        strokeOpacity,
+        vectorEffect: "non-scaling-stroke",
+        ...(svgEllipseProps.style || {}),
+      }}
+    />
+  )
+}
+
+Center.displayName = "Ellipse.Center"

--- a/src/display/Ellipse/Eccentricity.tsx
+++ b/src/display/Ellipse/Eccentricity.tsx
@@ -1,0 +1,25 @@
+import { Ellipse } from "../Ellipse"
+import { vec } from "../../vec"
+
+export interface EccentricityProps extends Filled {
+  focus1: vec.Vector2
+  focus2: vec.Vector2
+  eccentricity: number
+  svgEllipseProps?: React.SVGProps<SVGEllipseElement>
+}
+
+export function Eccentricity({
+  focus1,
+  focus2,
+  eccentricity
+}: EccentricityProps){
+  const center = vec.midpoint(focus1,focus2)
+  const angle = Math.atan2(focus1[1]-focus2[1],focus1[0]-focus2[0])
+  const focalDistance = vec.dist(focus1, center)
+  const semiMajorAxis = focalDistance/eccentricity
+  const semiMinorAxis = Math.sqrt(semiMajorAxis**2 - focalDistance**2)
+
+  return (
+    <Ellipse.Center center={center} radius={[semiMajorAxis, semiMinorAxis]} angle={angle}/>
+  )
+}

--- a/src/display/Ellipse/SemiMajorAxis.tsx
+++ b/src/display/Ellipse/SemiMajorAxis.tsx
@@ -1,0 +1,24 @@
+import { Ellipse } from "../Ellipse"
+import { vec } from "../../vec"
+
+export interface SemiMajorAxisProps extends Filled {
+  focus1: vec.Vector2
+  focus2: vec.Vector2
+  semiMajorAxis: number
+  svgEllipseProps?: React.SVGProps<SVGEllipseElement>
+}
+
+export function SemiMajorAxis({
+  focus1,
+  focus2,
+  semiMajorAxis
+}: SemiMajorAxisProps){
+  const center = vec.midpoint(focus1,focus2)
+  const angle = Math.atan2(focus1[1]-focus2[1],focus1[0]-focus2[0])
+  const focalDistance = vec.dist(focus1, center)
+  const semiMinorAxis = Math.sqrt(semiMajorAxis**2 - focalDistance**2)
+
+  return (
+    <Ellipse.Center center={center} radius={[semiMajorAxis, semiMinorAxis]} angle={angle}/>
+  )
+}

--- a/src/display/Ellipse/SemiMinorAxis.tsx
+++ b/src/display/Ellipse/SemiMinorAxis.tsx
@@ -1,0 +1,24 @@
+import { Ellipse } from "../Ellipse"
+import { vec } from "../../vec"
+
+export interface SemiMinorAxisProps extends Filled {
+  focus1: vec.Vector2
+  focus2: vec.Vector2
+  semiMinorAxis: number
+  svgEllipseProps?: React.SVGProps<SVGEllipseElement>
+}
+
+export function SemiMinorAxis({
+  focus1,
+  focus2,
+  semiMinorAxis
+}: SemiMinorAxisProps){
+  const center = vec.midpoint(focus1,focus2)
+  const angle = Math.atan2(focus1[1]-focus2[1],focus1[0]-focus2[0])
+  const focalDistance = vec.dist(focus1, center)
+  const semiMajorAxis = Math.sqrt(semiMinorAxis**2 + focalDistance**2)
+
+  return (
+    <Ellipse.Center center={center} radius={[semiMajorAxis, semiMinorAxis]} angle={angle}/>
+  )
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,7 +21,12 @@ export { Circle } from "./display/Circle"
 export type { CircleProps } from "./display/Circle"
 
 export { Ellipse } from "./display/Ellipse"
-export type { EllipseProps } from "./display/Ellipse"
+export type {
+  CenterProps,
+  EccentricityProps,
+  SemiMajorAxisProps,
+  SemiMinorAxisProps,
+} from "./display/Ellipse"
 
 export { Polygon } from "./display/Polygon"
 export type { PolygonProps } from "./display/Polygon"


### PR DESCRIPTION
Adds support for defining ellipses in terms of 2 foci and one of the following:
- Semi-Major Axis
- Semi-Minor Axis
- Eccentricity

todo: write tests